### PR TITLE
GlobalExceptionHandler를 통한 Security Redirect 로직 우회 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,11 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
 	// JPA end
 
+	// Test를 위한 H2database
+	runtimeOnly 'com.h2database:h2'
+	// Test를 위한 H2database
+
+
 	// Apple Oauth 관련 라이브러리 Start
 	implementation 'com.google.code.gson:gson:2.10.1'
 	// Apple Oauth 관련 라이브러리 End

--- a/src/main/java/com/gamemoonchul/application/AppleService.java
+++ b/src/main/java/com/gamemoonchul/application/AppleService.java
@@ -20,12 +20,16 @@ public class AppleService {
   private final MemberService memberService;
   private final TokenHelper tokenHelper;
 
-  public TokenDto signUp(AppleSignUpRequestDto signUpRequest) {
+  public AppleUserInfo validateRequest(AppleSignUpRequestDto signUpRequest) {
     AppleUserInfo appleUserInfo = appleIDTokenValidator.extractAppleUserinfoFromIDToken(signUpRequest.getIdentityToken());
     if(signUpRequest.getName() == null || signUpRequest.getName().isEmpty()) {
       throw new ApiException(AppleTokenStatus.INVALID_SIGNUP_FORM);
     }
     appleUserInfo.setName(signUpRequest.getName());
+    return appleUserInfo;
+  }
+
+  public TokenDto signInOrUp(AppleUserInfo appleUserInfo) {
     MemberEntity member = MemberConverter.toEntity(appleUserInfo);
     memberService.signInOrUp(member);
     TokenDto token  = tokenHelper.createToken(member.getEmail());

--- a/src/main/java/com/gamemoonchul/application/AppleService.java
+++ b/src/main/java/com/gamemoonchul/application/AppleService.java
@@ -8,18 +8,16 @@ import com.gamemoonchul.config.jwt.TokenDto;
 import com.gamemoonchul.config.jwt.TokenHelper;
 import com.gamemoonchul.domain.MemberEntity;
 import com.gamemoonchul.domain.converter.MemberConverter;
-import com.gamemoonchul.infrastructure.repository.MemberRepository;
 import com.gamemoonchul.infrastructure.web.dto.AppleSignUpRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class AppleService {
   private final AppleIDTokenValidator appleIDTokenValidator;
-  private final MemberRepository memberRepository;
+  private final MemberService memberService;
   private final TokenHelper tokenHelper;
 
   public TokenDto signUp(AppleSignUpRequestDto signUpRequest) {
@@ -28,18 +26,9 @@ public class AppleService {
       throw new ApiException(AppleTokenStatus.INVALID_SIGNUP_FORM);
     }
     appleUserInfo.setName(signUpRequest.getName());
-
-    Optional<MemberEntity> alreadyExistMember = memberRepository.findTop1ByEmail(appleUserInfo.getEmail());
-    MemberEntity member = new MemberEntity();
-
-    if (alreadyExistMember.isEmpty()) {
-      member = MemberConverter.toEntity(appleUserInfo);
-      memberRepository.save(member);
-    } else {
-      member = alreadyExistMember.get();
-    }
+    MemberEntity member = MemberConverter.toEntity(appleUserInfo);
+    memberService.signInOrUp(member);
     TokenDto token  = tokenHelper.createToken(member.getEmail());
-
     return token;
   }
 }

--- a/src/main/java/com/gamemoonchul/application/AppleService.java
+++ b/src/main/java/com/gamemoonchul/application/AppleService.java
@@ -1,7 +1,9 @@
 package com.gamemoonchul.application;
 
+import com.gamemoonchul.common.exception.ApiException;
 import com.gamemoonchul.config.apple.AppleIDTokenValidator;
 import com.gamemoonchul.config.apple.entities.AppleUserInfo;
+import com.gamemoonchul.config.apple.enums.AppleTokenStatus;
 import com.gamemoonchul.config.jwt.TokenDto;
 import com.gamemoonchul.config.jwt.TokenHelper;
 import com.gamemoonchul.domain.MemberEntity;
@@ -10,6 +12,8 @@ import com.gamemoonchul.infrastructure.repository.MemberRepository;
 import com.gamemoonchul.infrastructure.web.dto.AppleSignUpRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,12 +24,22 @@ public class AppleService {
 
   public TokenDto signUp(AppleSignUpRequestDto signUpRequest) {
     AppleUserInfo appleUserInfo = appleIDTokenValidator.extractAppleUserinfoFromIDToken(signUpRequest.getIdentityToken());
+    if(signUpRequest.getName() == null || signUpRequest.getName().isEmpty()) {
+      throw new ApiException(AppleTokenStatus.INVALID_SIGNUP_FORM);
+    }
     appleUserInfo.setName(signUpRequest.getName());
 
-    MemberEntity member = MemberConverter.toEntity(appleUserInfo);
-    memberRepository.save(member);
+    Optional<MemberEntity> alreadyExistMember = memberRepository.findTop1ByEmail(appleUserInfo.getEmail());
+    MemberEntity member = new MemberEntity();
 
+    if (alreadyExistMember.isEmpty()) {
+      member = MemberConverter.toEntity(appleUserInfo);
+      memberRepository.save(member);
+    } else {
+      member = alreadyExistMember.get();
+    }
     TokenDto token  = tokenHelper.createToken(member.getEmail());
+
     return token;
   }
 }

--- a/src/main/java/com/gamemoonchul/application/MemberService.java
+++ b/src/main/java/com/gamemoonchul/application/MemberService.java
@@ -12,12 +12,15 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class MemberService {
+
   private final MemberRepository memberRepository;
 
   public void signInOrUp(MemberEntity member) {
     Optional<MemberEntity> alreadyExistMember = memberRepository.findTop1ByEmail(member.getEmail());
     if (alreadyExistMember.isEmpty()) {
       memberRepository.save(member);
+    } else {
+      member = alreadyExistMember.get();
     }
   }
 

--- a/src/main/java/com/gamemoonchul/common/exceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/gamemoonchul/common/exceptionHandler/GlobalExceptionHandler.java
@@ -1,0 +1,15 @@
+package com.gamemoonchul.common.exceptionHandler;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(value = RuntimeException.class)
+    public ResponseEntity handleRuntimeException(RuntimeException e) {
+        // 알 수 없는 에러 반환
+        return ResponseEntity.status(500).body("An unknown error occurred.");
+    }
+}

--- a/src/main/java/com/gamemoonchul/common/filter/LoggerFilter.java
+++ b/src/main/java/com/gamemoonchul/common/filter/LoggerFilter.java
@@ -1,0 +1,59 @@
+package com.gamemoonchul.common.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class LoggerFilter implements Filter {
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+
+    var req = new ContentCachingRequestWrapper((HttpServletRequest) request);
+    var res = new ContentCachingResponseWrapper((HttpServletResponse) response);
+
+    ///# Do Filter 기준으로 실행 전과 실행 후가 나뉜다.
+    /// TODO: Header 정보와 Body 정보를 찍어주는게 좋음, 한 번 해볼 것
+    chain.doFilter(req, res);
+
+    // request 정보
+    var headerNames = req.getHeaderNames();
+    var headerValues = new StringBuilder();
+
+    /// TODO: asIterator() 란?
+    headerNames.asIterator().forEachRemaining(headerKey -> {
+      var headerValue = req.getHeader(headerKey);
+      // authorization-token : ??? , user-agent : ???
+      headerValues
+        .append("[")
+        .append(headerKey)
+        .append(" : ")
+        .append(headerValue).append("]");
+    });
+
+    var requestBody = new String(req.getContentAsByteArray());
+    var uri = req.getRequestURI();
+    var method = req.getMethod();
+    log.info(">>>>> uri : {} , method : {} , header : {} , body : {}", uri, method, headerValues, requestBody);
+
+    var responseHeaderValues = new StringBuilder();
+
+    res.getHeaderNames().forEach((headerKey) -> {
+      var headerValue = res.getHeader(headerKey);
+      responseHeaderValues.append("[").append(headerKey).append(" : ").append(headerValue).append("]");
+    });
+
+    var responseBody = new String(res.getContentAsByteArray());
+    log.info("<<<<< uri : {} , method : {} , header : {} , body : {}", uri, method, responseHeaderValues, responseBody);
+
+    res.copyBodyToResponse();
+  }
+}

--- a/src/main/java/com/gamemoonchul/config/apple/entities/AppleUserInfo.java
+++ b/src/main/java/com/gamemoonchul/config/apple/entities/AppleUserInfo.java
@@ -1,8 +1,7 @@
 package com.gamemoonchul.config.apple.entities;
 
 import com.google.gson.annotations.SerializedName;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 /************************************************************************
  Copyright 2020 eBay Inc.
@@ -21,6 +20,9 @@ import lombok.Setter;
  limitations under the License.
  **************************************************************************/
 
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class AppleUserInfo {
 
     /**

--- a/src/main/java/com/gamemoonchul/config/apple/enums/AppleTokenStatus.java
+++ b/src/main/java/com/gamemoonchul/config/apple/enums/AppleTokenStatus.java
@@ -26,6 +26,7 @@ public enum AppleTokenStatus implements ApiStatusIfs {
 
     // ID Token related errors
     INVALID_ID_TOKEN_SIGNATURE(50100, "ID Token signature verification failed"),
+    INVALID_SIGNUP_FORM(50105, "회원가입에 실패했습니다. 최초 회원 가입이 아니거나 이름을 제공하지 않았습니다."),
     INVALID_ID_TOKEN(50200,"Invalid ID Token"),
     EXPIRED_ID_TOKEN(50300, "Expired ID Token"),
     UNSUPPORTED_ID_TOKEN(50400, "Unsupported exception in Apple ID Token validation"),

--- a/src/main/java/com/gamemoonchul/infrastructure/repository/MemberRepository.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/repository/MemberRepository.java
@@ -3,9 +3,13 @@ package com.gamemoonchul.infrastructure.repository;
 
 import com.gamemoonchul.domain.MemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface MemberRepository  extends JpaRepository<MemberEntity, Long> {
   Optional<MemberEntity> findTop1ByEmail(String email);
+  List<MemberEntity> findByEmail(String email);
 }

--- a/src/main/java/com/gamemoonchul/infrastructure/web/AppleOpenApiController.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/AppleOpenApiController.java
@@ -1,7 +1,6 @@
 package com.gamemoonchul.infrastructure.web;
 
 import com.gamemoonchul.application.AppleService;
-import com.gamemoonchul.config.apple.AppleIDTokenValidator;
 import com.gamemoonchul.config.apple.entities.AppleUserInfo;
 import com.gamemoonchul.config.jwt.TokenDto;
 import com.gamemoonchul.infrastructure.web.common.RestControllerWithEnvelopPattern;
@@ -10,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestControllerWithEnvelopPattern
@@ -19,9 +17,9 @@ public class AppleOpenApiController {
   private final AppleService appleService;
 
   @PostMapping("/sign-up")
-  public TokenDto login(@RequestBody AppleSignUpRequestDto signUpRequest) {
-    TokenDto token = appleService.signUp(signUpRequest);
-
+  public TokenDto signInOrUp(@RequestBody AppleSignUpRequestDto signUpRequest) {
+    AppleUserInfo userInfo = appleService.validateRequest(signUpRequest);
+    TokenDto token = appleService.signInOrUp(userInfo);
     return token;
   }
 }

--- a/src/test/java/com/gamemoonchul/application/AppleServiceTest.java
+++ b/src/test/java/com/gamemoonchul/application/AppleServiceTest.java
@@ -1,0 +1,104 @@
+package com.gamemoonchul.application;
+
+import com.gamemoonchul.common.exception.ApiException;
+import com.gamemoonchul.config.apple.AppleIDTokenValidator;
+import com.gamemoonchul.config.apple.entities.AppleUserInfo;
+import com.gamemoonchul.domain.MemberEntity;
+import com.gamemoonchul.infrastructure.repository.MemberRepository;
+import com.gamemoonchul.infrastructure.web.dto.AppleSignUpRequestDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+public class AppleServiceTest {
+
+  @Autowired
+  MemberRepository memberRepository;
+
+  @Autowired
+  AppleService appleService;
+
+  @Autowired
+  AppleIDTokenValidator appleIDTokenValidator;
+
+  /**
+   * 모의개체 생성
+   */
+   @Mock
+    private AppleIDTokenValidator mockAppleIDTokenValidator;
+   @InjectMocks
+  private AppleService mockAppleService;
+
+
+    private AppleUserInfo mockAppleUserInfo;
+    private AppleSignUpRequestDto validSignUpRequest;
+    private AppleSignUpRequestDto invalidNameSignUpRequest;
+
+      @BeforeEach
+    void setUp() {
+        // 테스트 실행 전 필요한 객체를 초기화
+        mockAppleUserInfo = new AppleUserInfo();
+
+        validSignUpRequest = new AppleSignUpRequestDto("validToken", "John Doe"); // 유효한 가입 요청 객체
+        invalidNameSignUpRequest = new AppleSignUpRequestDto("validToken", null); // 이름이 유효하지 않은 가입 요청 객체
+
+        // AppleIDTokenValidator의 extractAppleUserinfoFromIDToken 메서드가 "validToken"을 받으면 mockAppleUserInfo를 반환하도록 설정
+        when(mockAppleIDTokenValidator.extractAppleUserinfoFromIDToken("validToken")).thenReturn(mockAppleUserInfo);
+    }
+
+    @Test
+    @DisplayName("유효한 토큰으로 Apple User Info 받아올 수 있는지를 검증한다.")
+    void validateRequestWithValidTokenReturnsUserInfo() {
+        // 유효한 토큰과 이름으로 validateRequest 메서드를 호출하고 결과를 검증
+        AppleUserInfo result = mockAppleService.validateRequest(validSignUpRequest);
+
+        // 반환된 AppleUserInfo 객체가 기대한 이름과 이메일을 가지고 있는지 확인
+        assertEquals("John Doe", result.getName());
+    }
+
+    @Test
+    @DisplayName("이름이 없는 경우 회원가입 ApiException이 발생하는지 검증한다.")
+    void validateRequestWithInvalidNameThrowsApiException() {
+        // 이름이 유효하지 않을 때 validateRequest 메서드를 호출하면 ApiException이 발생하는지 확인
+        assertThrows(ApiException.class, () -> {
+            mockAppleService.validateRequest(invalidNameSignUpRequest);
+        });
+    }
+
+
+  @Test
+  @DisplayName("signInOrUp 메서드를 통해서 생성될 수 있는 회원의 이메일은 중복되지 않아야 한다.")
+  public void signInOrUp() {
+    // given
+    AppleUserInfo appleUserInfo = AppleUserInfo.builder()
+        .issuer("yourIssuer")
+        .name("yourName")
+        .uniqueIdentifier("yourUniqueIdentifier")
+        .clientId("yourClientId")
+        .expiryTime("yourExpiryTime")
+        .issuingTime("yourIssuingTime")
+        .nonce("yourNonce")
+        .email("yourEmail")
+        .emailVerified(true)
+        .build();
+
+    // when
+    appleService.signInOrUp(appleUserInfo);
+    appleService.signInOrUp(appleUserInfo);
+    List<MemberEntity> members = memberRepository.findByEmail(appleUserInfo.getEmail());
+
+    // then
+    assertEquals(members.size(), 1);
+  }
+}


### PR DESCRIPTION
## Related Issue

Resolved : #22, Related to : #12

## Goal 

를 통해서 Spring Security의 Redirect 로직 우회

## Added Content 

- LoggerFilter 추가 
- Apple SignUp Service 개발 
- AppleStatus 이름 전송되지 않을 경우 발생시킬 메시지 추가 
- 알 수 없는 에러 발생시에 Redrect를 방지하기 위해서 GlobalExceptionHandler 전송
- Apple Service에서 MemberRepository로 바로 접근하지 않게 수정
- Test 코드 작성 용이를 위해 Request Validation과 로그인 로직 분리
- H2database 추가 
- AppleService 테스트 코드 추가 

## Screenshot (Optional) 

<img width="1084" alt="image" src="https://github.com/gamemuncheol/gamemuncheol-api/assets/67862775/a25a46f2-1c1b-40e9-b45a-3955f9136992">
