### PR TITLE
닉네임 변경 가능한지 (겹치는 닉네임이 없는지) 확인하는 API 개발

### DIFF
--- a/src/main/java/com/gamemoonchul/application/MemberService.java
+++ b/src/main/java/com/gamemoonchul/application/MemberService.java
@@ -58,10 +58,7 @@ public class MemberService {
 
     public boolean checkDuplicated(String nickName) {
         List<Member> savedMember = memberRepository.findByNickname(nickName);
-        if(savedMember.isEmpty()) {
-            return true;
-        }
-        return false;
+        return !savedMember.isEmpty();
     }
 
     public TokenDto renew(String refreshToken) {

--- a/src/main/java/com/gamemoonchul/application/MemberService.java
+++ b/src/main/java/com/gamemoonchul/application/MemberService.java
@@ -48,13 +48,20 @@ public class MemberService {
     }
 
     public void updateNickName(Member member, String nickName) {
-        List<Member> savedMember = memberRepository.findByNickname(nickName);
-        if (!savedMember.isEmpty()) {
+        if (validateNickname(nickName)) {
             log.error(MemberStatus.ALREADY_EXIST_NICKNAME.getMessage());
             throw new BadRequestException(MemberStatus.ALREADY_EXIST_NICKNAME);
         }
         Member updatedMember = member.updateNickname(nickName);
         memberRepository.save(updatedMember);
+    }
+
+    public boolean validateNickname(String nickName) {
+        List<Member> savedMember = memberRepository.findByNickname(nickName);
+        if(savedMember.isEmpty()) {
+            return true;
+        }
+        return false;
     }
 
     public TokenDto renew(String refreshToken) {

--- a/src/main/java/com/gamemoonchul/application/MemberService.java
+++ b/src/main/java/com/gamemoonchul/application/MemberService.java
@@ -48,7 +48,7 @@ public class MemberService {
     }
 
     public void updateNickName(Member member, String nickName) {
-        if (validateNickname(nickName)) {
+        if (checkDuplicated(nickName)) {
             log.error(MemberStatus.ALREADY_EXIST_NICKNAME.getMessage());
             throw new BadRequestException(MemberStatus.ALREADY_EXIST_NICKNAME);
         }
@@ -56,7 +56,7 @@ public class MemberService {
         memberRepository.save(updatedMember);
     }
 
-    public boolean validateNickname(String nickName) {
+    public boolean checkDuplicated(String nickName) {
         List<Member> savedMember = memberRepository.findByNickname(nickName);
         if(savedMember.isEmpty()) {
             return true;

--- a/src/main/java/com/gamemoonchul/infrastructure/web/MemberApiController.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/MemberApiController.java
@@ -6,12 +6,7 @@ import com.gamemoonchul.domain.entity.Member;
 import com.gamemoonchul.infrastructure.web.common.RestControllerWithEnvelopPattern;
 import com.gamemoonchul.infrastructure.web.dto.MemberResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-
-import java.util.Optional;
+import org.springframework.web.bind.annotation.*;
 
 @RestControllerWithEnvelopPattern
 @RequestMapping("/api/member")
@@ -26,6 +21,15 @@ public class MemberApiController {
     ) {
         memberService.updateNickName(member, nickname);
     }
+
+
+    @GetMapping("/duplication")
+    public boolean checkDuplicated(
+            @RequestParam(name = "nickname") String nickname
+    ) {
+        return memberService.checkDuplicated(nickname);
+    }
+
 
     @GetMapping("/me")
     public MemberResponseDto me(

--- a/src/main/java/com/gamemoonchul/infrastructure/web/MemberApiController.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/MemberApiController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberApiController {
     private final MemberService memberService;
 
-    @PatchMapping("/change-nickname/{nickname}")
+    @PatchMapping("/nickname/{nickname}")
     public void changeNickname(
             @MemberSession Member member,
             @PathVariable(name = "nickname") String nickname
@@ -22,14 +22,12 @@ public class MemberApiController {
         memberService.updateNickName(member, nickname);
     }
 
-
-    @GetMapping("/duplication")
-    public boolean checkDuplicated(
-            @RequestParam(name = "nickname") String nickname
+    @GetMapping("/nickname/{nickname}")
+    public boolean checkNicknameDuplicated(
+            @PathVariable(name = "nickname") String nickname
     ) {
         return memberService.checkDuplicated(nickname);
     }
-
 
     @GetMapping("/me")
     public MemberResponseDto me(

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,7 +56,7 @@ spring:
       client:
         registration:
           google:
-            client-id: ${GOOGLE_CLIENT_ID }
+            client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
             scope:
               - email

--- a/src/test/java/com/gamemoonchul/application/MemberServiceTest.java
+++ b/src/test/java/com/gamemoonchul/application/MemberServiceTest.java
@@ -6,11 +6,9 @@ import com.gamemoonchul.domain.entity.Member;
 import com.gamemoonchul.domain.entity.MemberDummy;
 import com.gamemoonchul.domain.status.MemberStatus;
 import com.gamemoonchul.infrastructure.repository.MemberRepository;
-import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
 
@@ -85,7 +83,7 @@ class MemberServiceTest extends TestDataBase {
         memberRepository.save(member);
 
         // when
-        boolean result = memberService.validateNickname(member.getNickname());
+        boolean result = memberService.checkDuplicated(member.getNickname());
 
         // then
         assertThat(result).isEqualTo(false);

--- a/src/test/java/com/gamemoonchul/application/MemberServiceTest.java
+++ b/src/test/java/com/gamemoonchul/application/MemberServiceTest.java
@@ -76,4 +76,18 @@ class MemberServiceTest extends TestDataBase {
                 .isInstanceOf(BadRequestException.class)
                 .hasMessageContaining(MemberStatus.ALREADY_EXIST_NICKNAME.getMessage());
     }
+
+    @Test
+    @DisplayName("validate 메서드에서 이미 존재하는 닉네임을 입력했을 때 false를 return 하는지 Test")
+    void validateNicknameTest() {
+        // given
+        Member member = MemberDummy.create();
+        memberRepository.save(member);
+
+        // when
+        boolean result = memberService.validateNickname(member.getNickname());
+
+        // then
+        assertThat(result).isEqualTo(false);
+    }
 }

--- a/src/test/java/com/gamemoonchul/application/MemberServiceTest.java
+++ b/src/test/java/com/gamemoonchul/application/MemberServiceTest.java
@@ -76,7 +76,7 @@ class MemberServiceTest extends TestDataBase {
     }
 
     @Test
-    @DisplayName("validate 메서드에서 이미 존재하는 닉네임을 입력했을 때 false를 return 하는지 Test")
+    @DisplayName("validate 메서드에서 이미 존재하는 닉네임을 입력했을 때 true를 return 하는지 Test")
     void validateNicknameTest() {
         // given
         Member member = MemberDummy.create();
@@ -86,6 +86,6 @@ class MemberServiceTest extends TestDataBase {
         boolean result = memberService.checkDuplicated(member.getNickname());
 
         // then
-        assertThat(result).isEqualTo(false);
+        assertThat(result).isEqualTo(true);
     }
 }

--- a/src/test/java/com/gamemoonchul/infrastructure/web/MemberApiControllerTest.java
+++ b/src/test/java/com/gamemoonchul/infrastructure/web/MemberApiControllerTest.java
@@ -42,7 +42,7 @@ class MemberApiControllerTest extends TestDataBase {
         String nickname = UUID.randomUUID().toString().substring(0, 8);
 
         // when
-        ResultActions resultActions = super.mvc.perform(patch("/api/member/change-nickname/" + nickname).header("Authorization", "Bearer " + tokenDto.getAccessToken()));
+        ResultActions resultActions = super.mvc.perform(patch("/api/member/nickname/" + nickname).header("Authorization", "Bearer " + tokenDto.getAccessToken()));
 
         // then
         resultActions.andExpect(status().isOk());


### PR DESCRIPTION
## Related Issue

Related to : #108 

## Goal 

닉네임 변경 가능한지 (겹치는 닉네임이 없는지) 확인하는 API

## Added Content 

- GET /api/member/nickname/{nickname} API 추가 (중복 확인)
- change-nickname API -> PATCH /api/member/nickname/{nickname}으로 변경
