### PR TITLE
modify: Delete API 추가 및 Comment API Restful하게 업데이트 

### DIFF
--- a/src/main/java/com/gamemoonchul/application/CommentService.java
+++ b/src/main/java/com/gamemoonchul/application/CommentService.java
@@ -56,7 +56,15 @@ public class CommentService {
     public void delete(Long commentId, Member authMember) {
         Comment savedComment = this.searchComment(commentId);
         validateSameMemberId(savedComment.getMember(), authMember);
+        commentCountDown(savedComment.getPost());
         commentRepository.delete(savedComment);
+    }
+
+    private void commentCountDown(Post post) {
+        Long curCount = post.getCommentCount();
+        curCount --;
+        post.setCommentCount(curCount);
+        postRepository.save(post);
     }
 
     private void validateSameMemberId(Member commentWriteMember, Member currentSignInMember) {

--- a/src/main/java/com/gamemoonchul/application/CommentService.java
+++ b/src/main/java/com/gamemoonchul/application/CommentService.java
@@ -1,7 +1,6 @@
 package com.gamemoonchul.application;
 
 import com.gamemoonchul.application.converter.CommentConverter;
-import com.gamemoonchul.common.exception.BadRequestException;
 import com.gamemoonchul.common.exception.NotFoundException;
 import com.gamemoonchul.common.exception.UnauthorizedException;
 import com.gamemoonchul.domain.entity.Comment;
@@ -61,9 +60,7 @@ public class CommentService {
     }
 
     private void commentCountDown(Post post) {
-        Long curCount = post.getCommentCount();
-        curCount --;
-        post.setCommentCount(curCount);
+        post.commentCountDown();
         postRepository.save(post);
     }
 

--- a/src/main/java/com/gamemoonchul/domain/entity/Post.java
+++ b/src/main/java/com/gamemoonchul/domain/entity/Post.java
@@ -38,11 +38,14 @@ public class Post extends BaseTimeEntity {
     private String content;
     @Builder.Default
     private Long viewCount = 0L;
-    @Setter
     @Builder.Default
     private Long commentCount=0L;
     @Builder.Default
     private Long voteCount=0L;
+
+    public void commentCountDown() {
+        this.commentCount --;
+    }
 
     public void addVoteOptions(List<VoteOptions> voteOptions) {
         if(this.voteOptions == null) {

--- a/src/main/java/com/gamemoonchul/domain/entity/Post.java
+++ b/src/main/java/com/gamemoonchul/domain/entity/Post.java
@@ -38,6 +38,7 @@ public class Post extends BaseTimeEntity {
     private String content;
     @Builder.Default
     private Long viewCount = 0L;
+    @Setter
     @Builder.Default
     private Long commentCount=0L;
     @Builder.Default

--- a/src/main/java/com/gamemoonchul/infrastructure/web/CommentApiController.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/CommentApiController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 public class CommentApiController {
     private final CommentService commentService;
 
-    @PutMapping
+    @PostMapping
     public void save(CommentRequest request, @MemberSession Member member) {
         commentService.save(request, member);
     }

--- a/src/main/java/com/gamemoonchul/infrastructure/web/CommentApiController.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/CommentApiController.java
@@ -7,9 +7,7 @@ import com.gamemoonchul.infrastructure.web.common.RestControllerWithEnvelopPatte
 import com.gamemoonchul.infrastructure.web.dto.CommentFixRequest;
 import com.gamemoonchul.infrastructure.web.dto.CommentRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/comment")
@@ -17,12 +15,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class CommentApiController {
     private final CommentService commentService;
 
-    @PostMapping("/save")
+    @PutMapping
     public void save(CommentRequest request, @MemberSession Member member) {
         commentService.save(request, member);
     }
 
-    @PatchMapping("/fix")
+    @PatchMapping
     public void fix(CommentFixRequest request, @MemberSession Member member) {
         commentService.fix(request, member);
     }

--- a/src/main/java/com/gamemoonchul/infrastructure/web/CommentApiController.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/CommentApiController.java
@@ -24,4 +24,9 @@ public class CommentApiController {
     public void fix(CommentFixRequest request, @MemberSession Member member) {
         commentService.fix(request, member);
     }
+
+    @DeleteMapping("/{id}")
+    public void del(@PathVariable(name= "id") Long id, @MemberSession Member member) {
+        commentService.delete(id, member);
+    }
 }

--- a/src/test/java/com/gamemoonchul/application/CommentServiceTest.java
+++ b/src/test/java/com/gamemoonchul/application/CommentServiceTest.java
@@ -1,7 +1,6 @@
 package com.gamemoonchul.application;
 
 import com.gamemoonchul.TestDataBase;
-import com.gamemoonchul.common.exception.BadRequestException;
 import com.gamemoonchul.common.exception.NotFoundException;
 import com.gamemoonchul.common.exception.UnauthorizedException;
 import com.gamemoonchul.domain.entity.*;

--- a/src/test/java/com/gamemoonchul/application/CommentServiceTest.java
+++ b/src/test/java/com/gamemoonchul/application/CommentServiceTest.java
@@ -17,6 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
@@ -135,6 +137,25 @@ class CommentServiceTest extends TestDataBase {
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining(PostStatus.COMMENT_NOT_FOUND.getMessage());
 
+    }
+
+    @Test
+    @DisplayName("댓글 삭제시 Comment Count가 감소하는지 테스트")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void shouldDecreaseCommentCountWhenCommentIsDeleted() throws InterruptedException {
+        // given
+        CommentRequest request = CommentDummy.createRequest(post.getId());
+        Comment savedComment = commentService.save(request, member);
+        post = postRepository.findById(post.getId()).orElseThrow();
+
+        // when
+        commentService.delete(savedComment.getId(), member);
+        em.clear();
+        Post post2 = postRepository.findById(post.getId())
+                .orElseThrow();
+
+        // then
+        assertThat(post.getCommentCount() - 1).isEqualTo(post2.getCommentCount());
     }
 
     @Test


### PR DESCRIPTION
## Related Issue

Related to : #94 

## Goal 

PR의 최종적 목표(이슈내용 간략히 요약)

## Overview 

- Comment 삭제 API 추가 
- Comment 삭제시 Post에서 Comment Count 감소 로직 추가 
- Comment 수정 / 추가 API Http Request Method로 구분
