### PR TITLE
유저 신규 등록시 닉네임까지 등록하도록 변경

### DIFF
--- a/src/main/java/com/gamemoonchul/MemberOpenApiService.java
+++ b/src/main/java/com/gamemoonchul/MemberOpenApiService.java
@@ -32,7 +32,7 @@ public class MemberOpenApiService {
         return newToken;
     }
 
-    public boolean checkDuplicatedNickname(String nickName) {
+    public boolean isExistNickname(String nickName) {
         List<Member> savedMember = memberRepository.findByNickname(nickName);
         return !savedMember.isEmpty();
     }
@@ -41,11 +41,12 @@ public class MemberOpenApiService {
         if (!request.privacyAgree()) {
             throw new UnauthorizedException(MemberStatus.CONSENT_REQUIRED);
         }
-        if (checkDuplicatedNickname(request.nickname())) {
+        if (isExistNickname(request.nickname())) {
             throw new BadRequestException(MemberStatus.ALREADY_EXIST_NICKNAME);
         }
 
         RedisMember redisMember = redisMemberService.findByTemporaryKey(request.temporaryKey());
+        redisMember.setNickname(request.nickname());
 
 
         Member member = MemberConverter.redisMemberToEntity(redisMember);

--- a/src/main/java/com/gamemoonchul/MemberOpenApiService.java
+++ b/src/main/java/com/gamemoonchul/MemberOpenApiService.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -33,8 +34,8 @@ public class MemberOpenApiService {
     }
 
     public boolean isExistNickname(String nickName) {
-        List<Member> savedMember = memberRepository.findByNickname(nickName);
-        return !savedMember.isEmpty();
+        Optional<Member> savedMember = memberRepository.findByNickname(nickName);
+        return savedMember.isPresent();
     }
 
     public TokenDto register(RegisterRequest request) {

--- a/src/main/java/com/gamemoonchul/application/MemberService.java
+++ b/src/main/java/com/gamemoonchul/application/MemberService.java
@@ -40,14 +40,14 @@ public class MemberService {
     }
 
     public void updateNickName(Member member, String nickName) {
-        if (checkDuplicatedNickname(nickName)) {
+        if (isExistNickname(nickName)) {
             throw new BadRequestException(MemberStatus.ALREADY_EXIST_NICKNAME);
         }
         Member updatedMember = member.updateNickname(nickName);
         memberRepository.save(updatedMember);
     }
 
-    private boolean checkDuplicatedNickname(String nickName) {
+    private boolean isExistNickname(String nickName) {
         List<Member> savedMember = memberRepository.findByNickname(nickName);
         return !savedMember.isEmpty();
     }

--- a/src/main/java/com/gamemoonchul/application/MemberService.java
+++ b/src/main/java/com/gamemoonchul/application/MemberService.java
@@ -48,8 +48,8 @@ public class MemberService {
     }
 
     private boolean isExistNickname(String nickName) {
-        List<Member> savedMember = memberRepository.findByNickname(nickName);
-        return !savedMember.isEmpty();
+        Optional<Member> savedMember = memberRepository.findByNickname(nickName);
+        return savedMember.isPresent();
     }
 
 

--- a/src/main/java/com/gamemoonchul/application/MemberService.java
+++ b/src/main/java/com/gamemoonchul/application/MemberService.java
@@ -1,10 +1,6 @@
 package com.gamemoonchul.application;
 
 import com.gamemoonchul.common.exception.BadRequestException;
-import com.gamemoonchul.config.jwt.TokenDto;
-import com.gamemoonchul.config.jwt.TokenHelper;
-import com.gamemoonchul.config.jwt.TokenInfo;
-import com.gamemoonchul.config.jwt.TokenType;
 import com.gamemoonchul.config.oauth.user.OAuth2Provider;
 import com.gamemoonchul.application.converter.MemberConverter;
 import com.gamemoonchul.domain.entity.Member;
@@ -44,18 +40,18 @@ public class MemberService {
     }
 
     public void updateNickName(Member member, String nickName) {
-        if (checkDuplicated(nickName)) {
-            log.error(MemberStatus.ALREADY_EXIST_NICKNAME.getMessage());
+        if (checkDuplicatedNickname(nickName)) {
             throw new BadRequestException(MemberStatus.ALREADY_EXIST_NICKNAME);
         }
         Member updatedMember = member.updateNickname(nickName);
         memberRepository.save(updatedMember);
     }
 
-    public boolean checkDuplicated(String nickName) {
+    private boolean checkDuplicatedNickname(String nickName) {
         List<Member> savedMember = memberRepository.findByNickname(nickName);
         return !savedMember.isEmpty();
     }
+
 
     public MemberResponseDto me(Member member) {
         MemberResponseDto response = memberConverter.toResponseDto(member);

--- a/src/main/java/com/gamemoonchul/domain/entity/Member.java
+++ b/src/main/java/com/gamemoonchul/domain/entity/Member.java
@@ -13,12 +13,13 @@ import lombok.experimental.SuperBuilder;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@AllArgsConstructor
-@NoArgsConstructor
-@SuperBuilder
-@Entity(name = "member")
 @Getter
 @Setter
+@Entity
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "member", uniqueConstraints = {@UniqueConstraint(columnNames = "nickname")})
 public class Member extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/gamemoonchul/domain/entity/VoteOptions.java
+++ b/src/main/java/com/gamemoonchul/domain/entity/VoteOptions.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 @Builder
 @Getter
-@Entity(name = "vote_options")
+@Entity(name = "vote_option")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class VoteOptions {

--- a/src/main/java/com/gamemoonchul/domain/entity/redis/RedisMember.java
+++ b/src/main/java/com/gamemoonchul/domain/entity/redis/RedisMember.java
@@ -27,4 +27,8 @@ public class RedisMember {
     private String email;
     private String picture;
     private LocalDateTime birth;
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/gamemoonchul/infrastructure/repository/MemberRepository.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/repository/MemberRepository.java
@@ -15,5 +15,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     List<Member> findAllByEmailAndProviderAndIdentifier(String email, OAuth2Provider issuer, String identifier);
 
-    List<Member> findByNickname(String nickname);
+    Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/com/gamemoonchul/infrastructure/web/MemberApiController.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/MemberApiController.java
@@ -22,12 +22,6 @@ public class MemberApiController {
         memberService.updateNickName(member, nickname);
     }
 
-    @GetMapping("/nickname/{nickname}")
-    public boolean checkNicknameDuplicated(
-            @PathVariable(name = "nickname") String nickname
-    ) {
-        return memberService.checkDuplicated(nickname);
-    }
 
     @GetMapping("/me")
     public MemberResponseDto me(

--- a/src/main/java/com/gamemoonchul/infrastructure/web/MemberOpenApiController.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/MemberOpenApiController.java
@@ -6,9 +6,7 @@ import com.gamemoonchul.infrastructure.web.common.RestControllerWithEnvelopPatte
 import com.gamemoonchul.infrastructure.web.dto.RenewRequest;
 import com.gamemoonchul.infrastructure.web.dto.RegisterRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/open-api/members")
@@ -20,6 +18,14 @@ public class MemberOpenApiController {
     public TokenDto renew(@RequestBody RenewRequest request) {
         return memberOpenApiService.renew(request.refreshToken());
     }
+
+        @GetMapping("/nickname/{nickname}")
+    public boolean checkNicknameDuplicated(
+            @PathVariable(name = "nickname") String nickname
+    ) {
+        return memberOpenApiService.checkDuplicatedNickname(nickname);
+    }
+
 
     @PostMapping("/register")
     public TokenDto register(@RequestBody RegisterRequest request) {

--- a/src/main/java/com/gamemoonchul/infrastructure/web/MemberOpenApiController.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/MemberOpenApiController.java
@@ -23,7 +23,7 @@ public class MemberOpenApiController {
     public boolean checkNicknameDuplicated(
             @PathVariable(name = "nickname") String nickname
     ) {
-        return memberOpenApiService.checkDuplicatedNickname(nickname);
+        return memberOpenApiService.isExistNickname(nickname);
     }
 
 

--- a/src/main/java/com/gamemoonchul/infrastructure/web/MemberOpenApiController.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/MemberOpenApiController.java
@@ -19,7 +19,7 @@ public class MemberOpenApiController {
         return memberOpenApiService.renew(request.refreshToken());
     }
 
-        @GetMapping("/nickname/{nickname}")
+    @GetMapping("/nickname/{nickname}")
     public boolean checkNicknameDuplicated(
             @PathVariable(name = "nickname") String nickname
     ) {

--- a/src/main/java/com/gamemoonchul/infrastructure/web/dto/RegisterRequest.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/dto/RegisterRequest.java
@@ -1,4 +1,4 @@
 package com.gamemoonchul.infrastructure.web.dto;
 
-public record RegisterRequest(String temporaryKey, boolean privacyAgree) {
+public record RegisterRequest(String temporaryKey, boolean privacyAgree, String nickname) {
 }

--- a/src/test/java/com/gamemoonchul/application/MemberServiceTest.java
+++ b/src/test/java/com/gamemoonchul/application/MemberServiceTest.java
@@ -57,18 +57,4 @@ class MemberServiceTest extends TestDataBase {
                 .isInstanceOf(BadRequestException.class)
                 .hasMessageContaining(MemberStatus.ALREADY_EXIST_NICKNAME.getMessage());
     }
-
-    @Test
-    @DisplayName("validate 메서드에서 이미 존재하는 닉네임을 입력했을 때 true를 return 하는지 Test")
-    void validateNicknameTest() {
-        // given
-        Member member = MemberDummy.create();
-        memberRepository.save(member);
-
-        // when
-        boolean result = memberService.checkDuplicated(member.getNickname());
-
-        // then
-        assertThat(result).isEqualTo(true);
-    }
 }

--- a/src/test/java/com/gamemoonchul/application/MemberServiceTest.java
+++ b/src/test/java/com/gamemoonchul/application/MemberServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -34,11 +35,11 @@ class MemberServiceTest extends TestDataBase {
 
         // when
         memberService.updateNickName(member, nickname);
-        List<Member> savedMember = memberRepository.findByNickname(nickname);
+        Optional<Member> savedMember = memberRepository.findByNickname(nickname);
 
         // then
-        assertThat(savedMember.size()).isEqualTo(1);
-        assertThat(savedMember.get(0).getNickname()).isEqualTo(nickname);
+        assertThat(savedMember.get()
+                .getNickname()).isEqualTo(nickname);
     }
 
     @Test

--- a/src/test/java/com/gamemoonchul/infrastructure/web/MemberOpenApiServiceTest.java
+++ b/src/test/java/com/gamemoonchul/infrastructure/web/MemberOpenApiServiceTest.java
@@ -2,8 +2,11 @@ package com.gamemoonchul.infrastructure.web;
 
 import com.gamemoonchul.MemberOpenApiService;
 import com.gamemoonchul.TestDataBase;
+import com.gamemoonchul.common.exception.BadRequestException;
+import com.gamemoonchul.domain.entity.Member;
 import com.gamemoonchul.domain.entity.MemberDummy;
 import com.gamemoonchul.domain.entity.redis.RedisMember;
+import com.gamemoonchul.domain.status.MemberStatus;
 import com.gamemoonchul.infrastructure.repository.MemberRepository;
 import com.gamemoonchul.infrastructure.repository.redis.RedisMemberRepository;
 import com.gamemoonchul.infrastructure.web.dto.RegisterRequest;
@@ -12,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 
 class MemberOpenApiServiceTest extends TestDataBase {
@@ -30,13 +34,53 @@ class MemberOpenApiServiceTest extends TestDataBase {
         // given
         RedisMember redisMember = MemberDummy.createRedisMember("hong");
         redisMember = redisMemberRepository.save(redisMember);
-        RegisterRequest request = new RegisterRequest(redisMember.getUniqueKey(), true);
+        RegisterRequest request = new RegisterRequest(redisMember.getUniqueKey(), true, "김문철");
 
         // when
         memberService.register(request);
 
         // then
-        assertThat(redisMemberRepository.findRedisMemberByUniqueKey(redisMember.getUniqueKey()).isPresent()).isFalse();
+        assertThat(redisMemberRepository.findRedisMemberByUniqueKey(redisMember.getUniqueKey())
+                .isPresent()).isFalse();
         assertThat(memberRepository.findTop1ByProviderAndIdentifier(redisMember.getProvider(), redisMember.getIdentifier())).isNotNull();
+    }
+
+    @Test
+    @DisplayName("중복된 닉네임이 있을 경우 register Exception 발생하는지 테스트")
+    void shouldThrowExceptionWhenNicknameIsDuplicate() {
+        // given
+        RedisMember redisMember1 = MemberDummy.createRedisMember("hong");
+        RedisMember redisMember2 = MemberDummy.createRedisMember("jong");
+        redisMember1 = redisMemberRepository.save(redisMember1);
+        redisMember2 = redisMemberRepository.save(redisMember2);
+        RegisterRequest request1 = new RegisterRequest(redisMember1.getUniqueKey(), true, "김문철");
+        RegisterRequest request2 = new RegisterRequest(redisMember1.getUniqueKey(), true, "김문철");
+        memberService.register(request1);
+
+        // when // then
+        assertThatThrownBy(() -> memberService.register(request2)
+        )
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining(MemberStatus.ALREADY_EXIST_NICKNAME.getMessage());
+
+
+        assertThat(redisMemberRepository.findRedisMemberByUniqueKey(redisMember1.getUniqueKey())
+                .isPresent()).isFalse();
+        assertThat(memberRepository.findTop1ByProviderAndIdentifier(redisMember1.getProvider(), redisMember1.getIdentifier())).isNotNull();
+    }
+
+
+    @Test
+    @DisplayName("validate 메서드에서 이미 존재하는 닉네임을 입력했을 때 true를 return 하는지 Test")
+    void validateNicknameTest() {
+        // given
+        Member member = MemberDummy.create();
+        memberRepository.save(member);
+
+        // when
+        boolean result = memberService.checkDuplicatedNickname(member.getNickname());
+
+        // then
+        assertThat(result).isEqualTo(true);
     }
 }


### PR DESCRIPTION
## Related Issue

Related to : #130 

## Overview

- RedisMemer에 setNickname 메서드 추가 
- nickname 중복 체크 API /open-api로 변경
- RegisterRequest에 nickname 추가