### PR TITLE
회원 탈퇴시 Post 및 댓글 삭제될 수 있도록 변경 

### DIFF
--- a/src/main/java/com/gamemoonchul/MemberOpenApiService.java
+++ b/src/main/java/com/gamemoonchul/MemberOpenApiService.java
@@ -1,7 +1,7 @@
 package com.gamemoonchul;
 
 import com.gamemoonchul.application.RedisMemberService;
-import com.gamemoonchul.application.converter.MemberConverter;
+import com.gamemoonchul.application.member.MemberConverter;
 import com.gamemoonchul.common.exception.BadRequestException;
 import com.gamemoonchul.common.exception.UnauthorizedException;
 import com.gamemoonchul.config.jwt.TokenDto;
@@ -14,9 +14,9 @@ import com.gamemoonchul.domain.status.MemberStatus;
 import com.gamemoonchul.infrastructure.repository.MemberRepository;
 import com.gamemoonchul.infrastructure.web.dto.RegisterRequest;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
@@ -37,7 +37,7 @@ public class MemberOpenApiService {
         return newToken;
     }
 
-    public boolean isExistNickname(@NotEmpty @Max(10) String nickName) {
+    public boolean isExistNickname(@NotEmpty @Length(max = 10) String nickName) {
         Optional<Member> savedMember = memberRepository.findByNickname(nickName);
         return savedMember.isPresent();
     }

--- a/src/main/java/com/gamemoonchul/MemberOpenApiService.java
+++ b/src/main/java/com/gamemoonchul/MemberOpenApiService.java
@@ -15,8 +15,8 @@ import com.gamemoonchul.infrastructure.repository.MemberRepository;
 import com.gamemoonchul.infrastructure.web.dto.RegisterRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.validator.constraints.Length;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
@@ -37,7 +37,7 @@ public class MemberOpenApiService {
         return newToken;
     }
 
-    public boolean isExistNickname(@NotEmpty @Length(max = 10) String nickName) {
+    public boolean isExistNickname(@NotEmpty @Size(max = 10) String nickName) {
         Optional<Member> savedMember = memberRepository.findByNickname(nickName);
         return savedMember.isPresent();
     }

--- a/src/main/java/com/gamemoonchul/application/converter/PostConverter.java
+++ b/src/main/java/com/gamemoonchul/application/converter/PostConverter.java
@@ -1,5 +1,6 @@
 package com.gamemoonchul.application.converter;
 
+import com.gamemoonchul.application.member.MemberConverter;
 import com.gamemoonchul.domain.entity.Member;
 import com.gamemoonchul.domain.entity.Post;
 import com.gamemoonchul.infrastructure.web.dto.PostResponseDto;

--- a/src/main/java/com/gamemoonchul/application/member/MemberConverter.java
+++ b/src/main/java/com/gamemoonchul/application/member/MemberConverter.java
@@ -1,4 +1,4 @@
-package com.gamemoonchul.application.converter;
+package com.gamemoonchul.application.member;
 
 import com.gamemoonchul.config.apple.AppleCredential;
 import com.gamemoonchul.config.oauth.user.OAuth2Provider;

--- a/src/main/java/com/gamemoonchul/application/member/MemberDeactivateService.java
+++ b/src/main/java/com/gamemoonchul/application/member/MemberDeactivateService.java
@@ -1,0 +1,54 @@
+package com.gamemoonchul.application.member;
+
+import com.gamemoonchul.common.exception.BadRequestException;
+import com.gamemoonchul.config.oauth.user.OAuth2Provider;
+import com.gamemoonchul.domain.entity.Comment;
+import com.gamemoonchul.domain.entity.Member;
+import com.gamemoonchul.domain.status.MemberStatus;
+import com.gamemoonchul.infrastructure.repository.CommentRepository;
+import com.gamemoonchul.infrastructure.repository.MemberRepository;
+import com.gamemoonchul.infrastructure.repository.PostRepository;
+import com.gamemoonchul.infrastructure.repository.VoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberDeactivateService {
+    private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final VoteRepository voteRepository;
+
+    public void deactivateAccount(String email, OAuth2Provider provider, String identifier) {
+        Optional<Member> member = memberRepository.findTop1ByProviderAndIdentifier(provider, identifier);
+        if (member.isEmpty()) {
+            throw new BadRequestException(MemberStatus.MEMBER_NOT_FOUND);
+        }
+        postRepository.deleteAllByMember(member.get());
+        voteRepository.deleteAllByMember(member.get());
+        commentRepository.deleteAll(requiredDeleteComments(member.get()));
+        memberRepository.delete(member.get());
+    }
+
+    private List<Comment> requiredDeleteComments(Member member) {
+        List<Comment> comments = commentRepository.findAllByMember(member);
+
+        List<Comment> requiredDelComments = new ArrayList<>(comments);
+        comments.stream()
+                .filter(it -> {
+                    return !it.parentExist();
+                })
+                .forEach(it -> {
+                    List<Comment> childComments = commentRepository.findByParentId(it.getId());
+                    requiredDelComments.addAll(childComments);
+                });
+        return requiredDelComments;
+    }
+}

--- a/src/main/java/com/gamemoonchul/application/member/MemberService.java
+++ b/src/main/java/com/gamemoonchul/application/member/MemberService.java
@@ -7,9 +7,9 @@ import com.gamemoonchul.domain.status.MemberStatus;
 import com.gamemoonchul.infrastructure.repository.MemberRepository;
 import com.gamemoonchul.infrastructure.web.dto.MemberResponseDto;
 import jakarta.transaction.Transactional;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.validator.constraints.Length;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
@@ -33,7 +33,7 @@ public class MemberService {
         return memberRepository.findTop1ByProviderAndIdentifier(provider, identifier);
     }
 
-    public void updateNickName(Member member, @Length(max = 10) String nickName) {
+    public void updateNickName(Member member, @Size(max = 10) String nickName) {
         if (isExistNickname(nickName)) {
             throw new BadRequestException(MemberStatus.ALREADY_EXIST_NICKNAME);
         }

--- a/src/main/java/com/gamemoonchul/application/member/MemberService.java
+++ b/src/main/java/com/gamemoonchul/application/member/MemberService.java
@@ -1,17 +1,15 @@
-package com.gamemoonchul.application;
+package com.gamemoonchul.application.member;
 
 import com.gamemoonchul.common.exception.BadRequestException;
 import com.gamemoonchul.config.oauth.user.OAuth2Provider;
-import com.gamemoonchul.application.converter.MemberConverter;
 import com.gamemoonchul.domain.entity.Member;
 import com.gamemoonchul.domain.status.MemberStatus;
 import com.gamemoonchul.infrastructure.repository.MemberRepository;
 import com.gamemoonchul.infrastructure.web.dto.MemberResponseDto;
 import jakarta.transaction.Transactional;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.validator.constraints.Length;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
@@ -35,16 +33,7 @@ public class MemberService {
         return memberRepository.findTop1ByProviderAndIdentifier(provider, identifier);
     }
 
-    public void deactivateAccount(String email, OAuth2Provider provider, String identifier) {
-        Optional<Member> member = memberRepository.findTop1ByProviderAndIdentifier(provider, identifier);
-        if (member.isEmpty()) {
-            log.error(MemberStatus.MEMBER_NOT_FOUND.getMessage());
-            throw new BadRequestException(MemberStatus.MEMBER_NOT_FOUND);
-        }
-        memberRepository.delete(member.get());
-    }
-
-    public void updateNickName(Member member, @NotEmpty @Max(10) String nickName) {
+    public void updateNickName(Member member, @Length(max = 10) String nickName) {
         if (isExistNickname(nickName)) {
             throw new BadRequestException(MemberStatus.ALREADY_EXIST_NICKNAME);
         }

--- a/src/main/java/com/gamemoonchul/common/handler/ApiExceptionHandler.java
+++ b/src/main/java/com/gamemoonchul/common/handler/ApiExceptionHandler.java
@@ -28,7 +28,6 @@ public class ApiExceptionHandler {
     public ResponseEntity<ApiResponse> validexception(
             MethodArgumentNotValidException exception
     ) {
-        log.error("", exception);
 
         List<String> errorMessageList = exception.getFieldErrors()
                 .stream()
@@ -47,7 +46,6 @@ public class ApiExceptionHandler {
     public ResponseEntity<ApiResponse> handleConstraintViolationException(
             ConstraintViolationException exception
     ) {
-        log.error("ConstraintViolationException: ", exception);
 
         List<String> errorMessageList = exception.getConstraintViolations()
                 .stream()

--- a/src/main/java/com/gamemoonchul/config/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/gamemoonchul/config/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,7 +1,8 @@
 package com.gamemoonchul.config.oauth.handler;
 
-import com.gamemoonchul.application.MemberService;
-import com.gamemoonchul.application.converter.MemberConverter;
+import com.gamemoonchul.application.member.MemberDeactivateService;
+import com.gamemoonchul.application.member.MemberService;
+import com.gamemoonchul.application.member.MemberConverter;
 import com.gamemoonchul.common.exception.BadRequestException;
 import com.gamemoonchul.common.exception.InternalServerException;
 import com.gamemoonchul.common.util.CookieUtils;
@@ -51,6 +52,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     private final OAuth2UserUnlinkManager oAuth2UserUnlinkManager;
     private final TokenHelper tokenProvider;
     private final MemberService memberService;
+    private final MemberDeactivateService memberDeactivateService;
     private final RedisMemberRepository redisMemberRepository;
 
     private final String TOKEN_DTO = "tokenDto";
@@ -147,7 +149,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
                 .getProvider();
 
         oAuth2UserUnlinkManager.unlink(provider, accessToken);
-        memberService.deactivateAccount(principal.getUserInfo()
+        memberDeactivateService.deactivateAccount(principal.getUserInfo()
                 .getEmail(), provider, principal.getUserInfo()
                 .getIdentifier());
     }

--- a/src/main/java/com/gamemoonchul/domain/entity/Post.java
+++ b/src/main/java/com/gamemoonchul/domain/entity/Post.java
@@ -22,7 +22,7 @@ public class Post extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @Setter
-    @JoinColumn(name = "member_id", referencedColumnName = "id")
+    @JoinColumn(name = "member_id")
     private Member member;
 
     @OneToMany(fetch = FetchType.LAZY)
@@ -30,7 +30,7 @@ public class Post extends BaseTimeEntity {
     private List<VoteOptions> voteOptions;
 
     @OneToMany(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id")
+    @JoinColumn(name = "post_id", updatable = false)
     private List<Comment> comments;
 
     @Column(name = "video_url")
@@ -81,12 +81,15 @@ public class Post extends BaseTimeEntity {
 
     public Double getMinVoteRatio() {
         int totalVoteCount = voteOptions.stream()
-                .mapToInt(voteOption -> voteOption.getVotes().size())
+                .mapToInt(voteOption -> voteOption.getVotes()
+                        .size())
                 .sum();
         if (totalVoteCount == 0) {
             return 0.0;
         }
-        double firstIndexVoteRatio = (double) voteOptions.get(0).getVotes().size() / (double) totalVoteCount * 100;
+        double firstIndexVoteRatio = (double) voteOptions.get(0)
+                .getVotes()
+                .size() / (double) totalVoteCount * 100;
         return Math.min(100.0 - firstIndexVoteRatio, firstIndexVoteRatio);
     }
 }

--- a/src/main/java/com/gamemoonchul/infrastructure/repository/CommentRepository.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.gamemoonchul.infrastructure.repository;
 
 import com.gamemoonchul.domain.entity.Comment;
+import com.gamemoonchul.domain.entity.Member;
 import com.gamemoonchul.infrastructure.repository.ifs.CommentRepositoryIfs;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,6 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryIfs {
     List<Comment> findByParentId(Long parentId);
+
+    List<Comment> findAllByMember(Member member);
 }

--- a/src/main/java/com/gamemoonchul/infrastructure/repository/PostRepository.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/repository/PostRepository.java
@@ -1,14 +1,21 @@
 package com.gamemoonchul.infrastructure.repository;
 
+import com.gamemoonchul.domain.entity.Member;
 import com.gamemoonchul.domain.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p JOIN FETCH p.member ORDER BY p.createdAt DESC")
     Page<Post> findAllByOrderByCreatedAt(Pageable pageable);
 
     Page<Post> findByVoteRatioGreaterThanEqual(Double ratio, Pageable pageable);
+
+    void deleteAllByMember(Member member);
+
+    List<Post> findByMember(Member member);
 }

--- a/src/main/java/com/gamemoonchul/infrastructure/repository/VoteRepository.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/repository/VoteRepository.java
@@ -1,0 +1,13 @@
+package com.gamemoonchul.infrastructure.repository;
+
+import com.gamemoonchul.domain.entity.Member;
+import com.gamemoonchul.domain.entity.Vote;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface VoteRepository extends JpaRepository<Vote, Long> {
+    void deleteAllByMember(Member member);
+
+    List<Vote> findByMember(Member member);
+}

--- a/src/main/java/com/gamemoonchul/infrastructure/web/MemberApiController.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/MemberApiController.java
@@ -1,6 +1,6 @@
 package com.gamemoonchul.infrastructure.web;
 
-import com.gamemoonchul.application.MemberService;
+import com.gamemoonchul.application.member.MemberService;
 import com.gamemoonchul.common.annotation.MemberSession;
 import com.gamemoonchul.domain.entity.Member;
 import com.gamemoonchul.infrastructure.web.common.RestControllerWithEnvelopPattern;

--- a/src/main/java/com/gamemoonchul/infrastructure/web/dto/PostResponseDto.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/dto/PostResponseDto.java
@@ -1,6 +1,6 @@
 package com.gamemoonchul.infrastructure.web.dto;
 
-import com.gamemoonchul.application.converter.MemberConverter;
+import com.gamemoonchul.application.member.MemberConverter;
 import com.gamemoonchul.domain.entity.Post;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/gamemoonchul/infrastructure/web/dto/RegisterRequest.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/dto/RegisterRequest.java
@@ -1,12 +1,11 @@
 package com.gamemoonchul.infrastructure.web.dto;
 
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.NotEmpty;
+import org.hibernate.validator.constraints.Length;
 
 public record RegisterRequest(
         String temporaryKey,
         boolean privacyAgree,
-        @NotEmpty @Max(10) String nickname
+        @Length(max = 10) String nickname
 ) {
 }

--- a/src/main/java/com/gamemoonchul/infrastructure/web/dto/RegisterRequest.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/dto/RegisterRequest.java
@@ -1,11 +1,11 @@
 package com.gamemoonchul.infrastructure.web.dto;
 
 
-import org.hibernate.validator.constraints.Length;
+import jakarta.validation.constraints.Size;
 
 public record RegisterRequest(
         String temporaryKey,
         boolean privacyAgree,
-        @Length(max = 10) String nickname
+        @Size(max = 10) String nickname
 ) {
 }

--- a/src/test/java/com/gamemoonchul/application/MemberServiceTest.java
+++ b/src/test/java/com/gamemoonchul/application/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package com.gamemoonchul.application;
 
 import com.gamemoonchul.TestDataBase;
+import com.gamemoonchul.application.member.MemberService;
 import com.gamemoonchul.common.exception.BadRequestException;
 import com.gamemoonchul.domain.entity.Member;
 import com.gamemoonchul.domain.entity.MemberDummy;
@@ -10,7 +11,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;

--- a/src/test/java/com/gamemoonchul/application/member/MemberDeactivateServiceTest.java
+++ b/src/test/java/com/gamemoonchul/application/member/MemberDeactivateServiceTest.java
@@ -1,0 +1,75 @@
+package com.gamemoonchul.application.member;
+
+import com.gamemoonchul.TestDataBase;
+import com.gamemoonchul.common.exception.BadRequestException;
+import com.gamemoonchul.config.oauth.user.OAuth2Provider;
+import com.gamemoonchul.domain.entity.Member;
+import com.gamemoonchul.domain.entity.MemberDummy;
+import com.gamemoonchul.domain.status.MemberStatus;
+import com.gamemoonchul.infrastructure.repository.CommentRepository;
+import com.gamemoonchul.infrastructure.repository.MemberRepository;
+import com.gamemoonchul.infrastructure.repository.PostRepository;
+import com.gamemoonchul.infrastructure.repository.VoteRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+class MemberDeactivateServiceTest extends TestDataBase {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private VoteRepository voteRepository;
+
+    @Autowired
+    private MemberDeactivateService memberDeactivateService;
+
+    @Test
+    @DisplayName("계정 비활성화가 정상적으로 되는지 테스트")
+    void deactivateAccount() {
+        // given
+        Member member = MemberDummy.create();
+        memberRepository.save(member);
+        String email = member.getEmail();
+        OAuth2Provider provider = member.getProvider();
+        String identifier = member.getIdentifier();
+
+        // when
+        memberDeactivateService.deactivateAccount(email, provider, identifier);
+
+        // then
+        Optional<Member> deletedMember = memberRepository.findTop1ByProviderAndIdentifier(provider, identifier);
+        assertThat(deletedMember).isEmpty();
+
+        assertThat(voteRepository.findByMember(member)).isEmpty();
+        assertThat(postRepository.findByMember(member)).isEmpty();
+        assertThat(commentRepository.findAllByMember(member)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 계정 비활성화 시 예외 발생하는지 테스트")
+    void deactivateNonExistentAccount() {
+        // given
+        String email = "nonexistent@example.com";
+        OAuth2Provider provider = OAuth2Provider.GOOGLE; // 예시로 GOOGLE 사용
+        String identifier = "nonexistent_identifier";
+
+        // when & then
+        assertThatThrownBy(() -> memberDeactivateService.deactivateAccount(email, provider, identifier))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining(MemberStatus.MEMBER_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## Related Issue

close : #145 

## Overview

- Nickname validation max -> length 수정
- MemberDeactivateService 개발 
- MemberService, MemberConverter -> application/member 폴더로 이동
- Post updatable false 옵션으로 Post 삭제시 Comment의 post_id null로 만들던 버그 수정
- MemberDeactivateService 테스트 작성
