### PR TITLE
Spring Server 최적화

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,9 +41,12 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     hikari:
-      maximum-pool-size: 30
-      minimum-idle: 20
-      connection-timeout: 30000 # 30 seconds
+      maximum-pool-size: 4
+      minimum-idle: 4
+      connection-timeout: 30000 # 30s
+      idle-timeout: 600000 # 10분, 유휴 연결의 최대 유지 시간
+      max-lifetime: 1800000 # 30분, 연결의 최대 수명
+
 
   data:
     redis:
@@ -83,12 +86,12 @@ spring:
 server:
   tomcat:
     threads:
-      max: 500 # 최대 동시 요청수, 기본 200
+      max: 150 # 최대 동시 요청수, 기본 200
       min-spare: 20 # 최소한 유지하는 스레드 수, 기본 10
-    max-connections: 8192
+    max-connections: 2000
     #  대기 중인 연결 큐의 최대 크기
     # 대기열이 꽉 차면 추가 요청은 거절됨 (기본값 100)
-    accept-count: 1000 # 대기 중인 연결 큐의 최대 크기,
+    accept-count: 500 # 대기 중인 연결 큐의 최대 크기,
 
 apple:
   clientId: ${APPLE_CLIENT_ID}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -42,7 +42,7 @@ spring:
     password: ${DB_PASSWORD}
     hikari:
       maximum-pool-size: 30
-      minimum-idle: 5
+      minimum-idle: 20
       connection-timeout: 30000 # 30 seconds
 
   data:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -91,7 +91,8 @@ server:
     max-connections: 2000
     #  대기 중인 연결 큐의 최대 크기
     # 대기열이 꽉 차면 추가 요청은 거절됨 (기본값 100)
-    accept-count: 500 # 대기 중인 연결 큐의 최대 크기,
+    accept-count: 2000 # 대기 중인 연결 큐의 최대 크기,
+    connection-timeout: 180000 # 3분, 클라이언트 연결 대기 시간
 
 apple:
   clientId: ${APPLE_CLIENT_ID}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -40,6 +40,11 @@ spring:
     driver-class-name: com.mysql.jdbc.Driver
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+    hikari:
+      maximum-pool-size: 20
+      minimum-idle: 5
+      connection-timeout: 30000 # 30 seconds
+
   data:
     redis:
       host: ${REDIS_HOST}
@@ -74,6 +79,16 @@ spring:
             authorization-uri: https://appleid.apple.com/auth/authorize?response_mode=form_post
             token-uri: https://appleid.apple.com/auth/token
             jwk-set-uri: https://appleid.apple.com/auth/keys
+
+server:
+  tomcat:
+    threads:
+      max: 500 # 최대 동시 요청수, 기본 200
+      min-spare: 20 # 최소한 유지하는 스레드 수, 기본 10
+    max-connections: 8192
+    #  대기 중인 연결 큐의 최대 크기
+    # 대기열이 꽉 차면 추가 요청은 거절됨 (기본값 100)
+    accept-count: 1000 # 대기 중인 연결 큐의 최대 크기,
 
 apple:
   clientId: ${APPLE_CLIENT_ID}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,7 +41,7 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     hikari:
-      maximum-pool-size: 20
+      maximum-pool-size: 30
       minimum-idle: 5
       connection-timeout: 30000 # 30 seconds
 


### PR DESCRIPTION
## Related Issue

Related to : 
- #180 

## Overview

- Thread Pool 설정 변경
- HikariCP DB Connection Pool 설정 변경

## ScreenShot 

### 1000명 동시요청 상황

실패율 21.5%에서 실패율 0%로 개선

- 적용 전

![image](https://github.com/user-attachments/assets/32a19beb-4b9b-4eeb-933c-941e629b6f1a)

- 적용 후

![image](https://github.com/user-attachments/assets/3744d68c-1013-458e-9182-23075a2e265c)

### 10명 동시요청 상황

실패율 386ms에서 실패율 308ms로 개선

- 적용 전

![image](https://github.com/user-attachments/assets/52c1923b-90db-48da-b737-6a7278f38c8a)

- 적용 후

![image](https://github.com/user-attachments/assets/7eb948ad-5103-4adb-9fbc-9651655d65f2)
