### PR TITLE
[REFACTOR-192] 낙관락 vs 비관락 성능 비교

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // Optimistic Retry
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework:spring-aspects'
+
     // flyway
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'

--- a/src/main/java/com/gamemoonchul/GamemoonchulApplication.java
+++ b/src/main/java/com/gamemoonchul/GamemoonchulApplication.java
@@ -3,7 +3,9 @@ package com.gamemoonchul;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 
+@EnableRetry
 @EnableJpaAuditing
 @SpringBootApplication
 public class GamemoonchulApplication {

--- a/src/main/java/com/gamemoonchul/application/CommentService.java
+++ b/src/main/java/com/gamemoonchul/application/CommentService.java
@@ -14,6 +14,10 @@ import com.gamemoonchul.infrastructure.repository.PostRepository;
 import com.gamemoonchul.infrastructure.web.dto.request.CommentFixRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.StaleObjectStateException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,16 +38,26 @@ public class CommentService {
     /**
      * 테스트를 하기 위해서 실제 Post, Member가 객체맵핑 되있어야 합니다.
      */
+    @Retryable(
+        retryFor = {
+            StaleObjectStateException.class,
+            ObjectOptimisticLockingFailureException.class},
+        maxAttempts = 3, // 최대 시도 횟수
+        backoff = @Backoff(
+            random = true,
+            maxDelay = 200
+        ) // 재시도 간의 대기 시간 (1000ms)
+    )
     public Comment save(CommentSaveDto request, Member member) {
         validatePostNotReplied(request);
         Post post = postRepository.findByIdForUpdate(request.postId())
-                .orElseThrow(() -> new NotFoundException(PostStatus.POST_NOT_FOUND));
+            .orElseThrow(() -> new NotFoundException(PostStatus.POST_NOT_FOUND));
         Comment comment = Comment.builder()
-                .parentId(request.parentId())
-                .member(member)
-                .post(post)
-                .content(request.content())
-                .build();
+            .parentId(request.parentId())
+            .member(member)
+            .post(post)
+            .content(request.content())
+            .build();
 
         post.commentCountUp();
         postRepository.save(post);
@@ -57,12 +71,12 @@ public class CommentService {
     private void validatePostNotReplied(CommentSaveDto request) {
         if (request.parentId() != null) {
             Comment parentComment = commentRepository.findById(request.parentId())
-                    .orElseThrow(() -> new BadRequestException(PostStatus.COMMENT_NOT_FOUND));
+                .orElseThrow(() -> new BadRequestException(PostStatus.COMMENT_NOT_FOUND));
             if (parentComment.getParentId() != null) {
                 throw new BadRequestException(PostStatus.COMMENT_CANT_HAVE_GRANDMOTHER);
             } else if (!parentComment.getPost()
-                    .getId()
-                    .equals(request.postId())) {
+                .getId()
+                .equals(request.postId())) {
                 throw new BadRequestException(PostStatus.INVALID_REPLY);
             }
         }
@@ -70,7 +84,7 @@ public class CommentService {
 
     public Comment fix(CommentFixRequest request, Long requestMemberId) {
         Comment modifiedComment = commentRepository.findById(request.commentId())
-                .orElseThrow(() -> new NotFoundException(PostStatus.COMMENT_NOT_FOUND));
+            .orElseThrow(() -> new NotFoundException(PostStatus.COMMENT_NOT_FOUND));
         modifiedComment.setContent(request.contents());
         // 글 작성자
         validateSameMemberId(modifiedComment.getMember(), requestMemberId);
@@ -94,7 +108,7 @@ public class CommentService {
      */
     public Comment searchComment(Long commentId) {
         Comment comment = commentRepository.findByIdForUpdate(commentId)
-                .orElseThrow(() -> new NotFoundException(PostStatus.COMMENT_NOT_FOUND));
+            .orElseThrow(() -> new NotFoundException(PostStatus.COMMENT_NOT_FOUND));
         return comment;
     }
 

--- a/src/main/java/com/gamemoonchul/application/CommentService.java
+++ b/src/main/java/com/gamemoonchul/application/CommentService.java
@@ -42,15 +42,16 @@ public class CommentService {
         retryFor = {
             StaleObjectStateException.class,
             ObjectOptimisticLockingFailureException.class},
-        maxAttempts = 3, // 최대 시도 횟수
+        maxAttempts = 5, // 최대 시도 횟수
         backoff = @Backoff(
+            delay = 0,
             random = true,
-            maxDelay = 200
+            maxDelay = 10000
         ) // 재시도 간의 대기 시간 (1000ms)
     )
     public Comment save(CommentSaveDto request, Member member) {
         validatePostNotReplied(request);
-        Post post = postRepository.findByIdForUpdate(request.postId())
+        Post post = postRepository.findById(request.postId())
             .orElseThrow(() -> new NotFoundException(PostStatus.POST_NOT_FOUND));
         Comment comment = Comment.builder()
             .parentId(request.parentId())

--- a/src/main/java/com/gamemoonchul/application/post/PostOpenApiService.java
+++ b/src/main/java/com/gamemoonchul/application/post/PostOpenApiService.java
@@ -42,7 +42,7 @@ public class PostOpenApiService {
             redisPostDetail = optionalPostDetail.get();
         }
 
-        List<CommentResponse> comments = commentService.searchByPostId(optionalPostDetail.get().getId(), requestMemberId).stream()
+        List<CommentResponse> comments = commentService.searchByPostId(redisPostDetail.getId(), requestMemberId).stream()
             .map(CommentResponse::entityToResponse).toList(); // 변경 자주 일어남, 캐싱 X
         redisPostDetail.setComments(comments);
 

--- a/src/main/java/com/gamemoonchul/domain/entity/Post.java
+++ b/src/main/java/com/gamemoonchul/domain/entity/Post.java
@@ -64,6 +64,9 @@ public class Post extends BaseTimeEntity {
     @Column(name = "vote_ratio")
     private Double voteRatio = 0.0;
 
+    @Version
+    private Integer version;
+
     public void commentCountDown() {
         this.commentCount--;
     }

--- a/src/main/resources/db/migration/V1__init_tables.sql
+++ b/src/main/resources/db/migration/V1__init_tables.sql
@@ -1,4 +1,4 @@
-create table comment
+CREATE TABLE IF NOT EXISTS comment
 (
     id         bigint auto_increment
         primary key,
@@ -11,7 +11,7 @@ create table comment
 )
     engine = InnoDB;
 
-create table match_game
+CREATE TABLE IF NOT EXISTS match_game
 (
     id            bigint auto_increment
         primary key,
@@ -24,7 +24,7 @@ create table match_game
 )
     engine = InnoDB;
 
-create table match_user
+CREATE TABLE IF NOT EXISTS match_user
 (
     id            bigint auto_increment
         primary key,
@@ -36,7 +36,7 @@ create table match_user
 )
     engine = InnoDB;
 
-create table member
+CREATE TABLE IF NOT EXISTS member
 (
     id                bigint auto_increment
         primary key,
@@ -60,7 +60,7 @@ create table member
 )
     engine = InnoDB;
 
-create table member_ban
+CREATE TABLE IF NOT EXISTS member_ban
 (
     id            bigint auto_increment
         primary key,
@@ -71,10 +71,10 @@ create table member_ban
 )
     engine = InnoDB;
 
-create index idx_member_ban_banned_member_id
-    on member_ban (member_id);
+CREATE INDEX IF NOT EXISTS idx_member_ban_banned_member_id
+    ON member_ban (member_id);
 
-create table post
+CREATE TABLE IF NOT EXISTS post
 (
     id            bigint auto_increment
         primary key,
@@ -93,7 +93,7 @@ create table post
 )
     engine = InnoDB;
 
-create table post_ban
+CREATE TABLE IF NOT EXISTS post_ban
 (
     id          bigint auto_increment
         primary key,
@@ -104,10 +104,10 @@ create table post_ban
 )
     engine = InnoDB;
 
-create index idx_post_ban_banned_member_id
-    on post_ban (member_id);
+CREATE INDEX IF NOT EXISTS idx_post_ban_banned_member_id
+    ON post_ban (member_id);
 
-create table post_view
+CREATE TABLE IF NOT EXISTS post_view
 (
     id         bigint auto_increment
         primary key,
@@ -117,17 +117,17 @@ create table post_view
 )
     engine = InnoDB;
 
-create index idx_post_view_created_at_post_id
-    on post_view (created_at, post_id);
+CREATE INDEX IF NOT EXISTS idx_post_view_created_at_post_id
+    ON post_view (created_at, post_id);
 
-create table test
+CREATE TABLE IF NOT EXISTS test
 (
     id   int         null,
     name varchar(50) null
 )
     engine = InnoDB;
 
-create table user_test
+CREATE TABLE IF NOT EXISTS user_test
 (
     id   int          not null
         primary key,
@@ -135,7 +135,7 @@ create table user_test
 )
     engine = InnoDB;
 
-create table vote
+CREATE TABLE IF NOT EXISTS vote
 (
     id              bigint auto_increment
         primary key,
@@ -149,13 +149,13 @@ create table vote
 )
     engine = InnoDB;
 
-create index idx_created_at
-    on vote (created_at);
+CREATE INDEX IF NOT EXISTS idx_created_at
+    ON vote (created_at);
 
-create index idx_updated_at
-    on vote (updated_at);
+CREATE INDEX IF NOT EXISTS idx_updated_at
+    ON vote (updated_at);
 
-create table vote_option
+CREATE TABLE IF NOT EXISTS vote_option
 (
     id            bigint auto_increment
         primary key,
@@ -163,4 +163,3 @@ create table vote_option
     match_user_id bigint null
 )
     engine = InnoDB;
-

--- a/src/main/resources/db/migration/V3__add_post_version_column.sql
+++ b/src/main/resources/db/migration/V3__add_post_version_column.sql
@@ -1,0 +1,2 @@
+alter table post
+    add column version int not null default 0;


### PR DESCRIPTION
## Related Issue

Related to : #192 

## Overview

### Test Case 1

```js
export let options = {
  stages: [
    { duration: "2m", target: 10 }, // 2분 동안 10명의 사용자가 증가
    { duration: "2m", target: 20 }, // 2분 동안 20명으로 유지
    { duration: "2m", target: 20 },
    { duration: "2m", target: 0 },
  ],
};
```

- 비관락
TPS : 13.61 / 응답속도 : 224ms

![비관락테스트-v1](https://github.com/user-attachments/assets/10918742-e291-4971-9411-87de4ea1e8f3)

- 낙관락 
TPS : 10 / 응답속도 189ms

![낙관락테스트-v1](https://github.com/user-attachments/assets/0b418087-d7f4-4f88-948b-58bbb11b3952)

낙관락이 더 빠른 것처럼 보이지만 실패율이 27%라서 낙관락을 적용한 API가 안정적이라고 할 수 없음
따라서 지금 테스트 조건으로는 한 번에 몰리는 트래픽이 있기 때문에 낙관락이 비관락보다 우세하다고 할 수 없음

### Test Case 2 

동시접속자수가 3명 정도 있는 서비스라고 가정하고 Request 요청이 Random한 시간에 일어난다고 가정

- Stage 설정

```js
export let options = {
  // iterations: 25,
  stages: [
    { duration: "10s", target: 1 },
    { duration: "10s", target: 2 },
    { duration: "30s", target: 3 },
    { duration: "10s", target: 2 },
    { duration: "10s", target: 1 },
  ],
};
```

- 요청 타이밍 설정

```js
  const randomSleepMs = Math.random() * 10000; // 0ms ~ 10000ms
  sleep(randomSleepMs / 1000);  // 초 단위로 변환하여 sleep 호출

  const res = http.post(apiUrl, payload, params);
  check(res, {
    "is status 200": (r) => r.status === 200,
  });
```

- 낙관적 락 테스트 1
실패율 : 4.76% / 응답속도 : 203.54ms

<img width="832" alt="image" src="https://github.com/user-attachments/assets/2a12d2fe-7c26-4395-87fb-d9ce138970fd">

- 낙관적 락 테스트 2
실패율 : 0% / 응답속도 : 229.62ms

어쨋든 요청이 성공하긴 해야한다는 조건이 있어서 Retry 횟수를 50까지 늘려줬다.

<img width="811" alt="image" src="https://github.com/user-attachments/assets/bbc2601b-a4cc-49bd-a868-2973689392db">

- 비관적 락
실패율 : 0% / 응답속도 : 331.54ms

<img width="804" alt="image" src="https://github.com/user-attachments/assets/219dbba7-4c85-40fc-a844-6f005cd1d0d6">

### 결론

Retryable을 랜덤으로 주고 실상황에서 Race Condition 문제가 발생할 확률을 고려했을 때, 낙관적 락 전략을 사용하기로 했다.

## Retryable을 Random으로 줘야 하는 이유 

이전에 테스트를 진행했을 때, 비관적락이 어떠한 경우에서도 낙관적 락보다 빨랐다. 지금 생각해보면 충돌이 단 한 번이라도 일어나면 비관적락보다 느려질 수 밖에 없어지는 구조였던 것 같다. 최근에 [TheWing](https://github.com/sujl95)님을 만나서 이 현상에 대해서 조언을 들었는데, 비관락을 사용할 때 재시도 간격을 동일하게 준게 아니냐는 얘기를 들어서 재시도 간격에 따른 성능을 비교해보고자 한다.

- Retryable을 재시도 시간을 랜덤하게 주지 않았을 때 

<img width="795" alt="image" src="https://github.com/user-attachments/assets/8d8c8e1f-8f19-4ac7-9e40-8dff74f0358d">

- Retryable을 재시도 시간을 랜덤하게 줬을 때 

실패율이 무려 8배 가까이 줄어든 것을 알 수 있다.

<img width="795" alt="image" src="https://github.com/user-attachments/assets/1f6e1c84-81fb-4c5b-a1d3-ab4fb27fa52a">
