### PR TITLE
Response도 전부 record로 변경 및 Converter에서 변경하도록 변경

### DIFF
--- a/src/main/java/com/gamemoonchul/application/RiotApiService.java
+++ b/src/main/java/com/gamemoonchul/application/RiotApiService.java
@@ -1,5 +1,6 @@
 package com.gamemoonchul.application;
 
+import com.gamemoonchul.application.converter.MatchGameConverter;
 import com.gamemoonchul.application.ports.output.RiotApiPort;
 import com.gamemoonchul.domain.entity.riot.MatchGame;
 import com.gamemoonchul.domain.model.vo.riot.MatchRecord;
@@ -29,9 +30,9 @@ public class RiotApiService {
             MatchRecord vo = riotApi.searchMatch(gameId);
             matchGame = matchGameService.save(vo);
             matchUserService.saveAll(vo.info()
-                    .participants(), matchGame);
+                .participants(), matchGame);
         }
-        MatchGameResponse response = MatchGameResponse.toResponse(matchGame);
+        MatchGameResponse response = MatchGameConverter.toResponse(matchGame);
         return response;
     }
 }

--- a/src/main/java/com/gamemoonchul/application/converter/CommentConverter.java
+++ b/src/main/java/com/gamemoonchul/application/converter/CommentConverter.java
@@ -1,0 +1,16 @@
+package com.gamemoonchul.application.converter;
+
+import com.gamemoonchul.common.util.StringUtils;
+import com.gamemoonchul.domain.entity.Comment;
+import com.gamemoonchul.infrastructure.web.dto.response.CommentResponse;
+
+public class CommentConverter {
+    public static CommentResponse toResponse(Comment entity) {
+        return CommentResponse.builder()
+            .author(MemberConverter.toResponseDto(entity.getMember()))
+            .content(entity.getContent())
+            .timesAgo(StringUtils.getTimeAgo(entity.getCreatedAt()))
+            .build();
+    }
+
+}

--- a/src/main/java/com/gamemoonchul/application/converter/MatchGameConverter.java
+++ b/src/main/java/com/gamemoonchul/application/converter/MatchGameConverter.java
@@ -1,4 +1,20 @@
 package com.gamemoonchul.application.converter;
 
+import com.gamemoonchul.domain.entity.riot.MatchGame;
+import com.gamemoonchul.infrastructure.web.dto.response.MatchGameResponse;
+
 public class MatchGameConverter {
+    public static MatchGameResponse toResponse(MatchGame matchGame) {
+        return MatchGameResponse.builder()
+            .gameId(matchGame.getGameId())
+            .gameCreation(matchGame.getGameCreation())
+            .gameDuration(matchGame.getGameDuration())
+            .gameMode(matchGame.getGameMode())
+            .matchUsers(matchGame.getMatchUsers()
+                .stream()
+                .map(MatchUserConverter::toResponse)
+                .toList())
+            .build();
+    }
+
 }

--- a/src/main/java/com/gamemoonchul/application/converter/MatchGameConverter.java
+++ b/src/main/java/com/gamemoonchul/application/converter/MatchGameConverter.java
@@ -1,0 +1,4 @@
+package com.gamemoonchul.application.converter;
+
+public class MatchGameConverter {
+}

--- a/src/main/java/com/gamemoonchul/application/converter/MatchUserConverter.java
+++ b/src/main/java/com/gamemoonchul/application/converter/MatchUserConverter.java
@@ -1,0 +1,56 @@
+package com.gamemoonchul.application.converter;
+
+import com.gamemoonchul.common.util.PropertyUtil;
+import com.gamemoonchul.domain.entity.riot.MatchUser;
+import com.gamemoonchul.infrastructure.web.dto.response.MatchUserResponse;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Properties;
+
+@Slf4j
+public class MatchUserConverter {
+    public static MatchUserResponse toResponse(MatchUser matchUser) {
+        String koChampName = getKoChampName(PropertyUtil.loadProperties(), matchUser);
+
+        return MatchUserResponse.builder()
+            .id(matchUser.getId())
+            .nickname(matchUser.getNickname())
+            .championName(koChampName)
+            .championThumbnail(getChampThumbnail(matchUser.getChampionName()))
+            .win(matchUser.isWin())
+            .build();
+    }
+
+    /**
+     * @param matchUser "VoteOption"의 "MatchUser"
+     * @param voId      "VoteOption의 ID"
+     */
+    public static MatchUserResponse toResponseVoId(MatchUser matchUser, Long voId) {
+        String koChampName = getKoChampName(PropertyUtil.loadProperties(), matchUser);
+
+        return MatchUserResponse.builder()
+            .id(voId)
+            .nickname(matchUser.getNickname())
+            .championName(koChampName)
+            .championThumbnail(getChampThumbnail(matchUser.getChampionName()))
+            .win(matchUser.isWin())
+            .build();
+    }
+
+    public static String getChampThumbnail(String championName) {
+        return "https://ddragon.leagueoflegends.com/cdn/img/champion/splash/" + championName + "_0.jpg";
+    }
+
+    private static String getKoChampName(Properties properties, MatchUser matchUser) {
+        String engChampName = matchUser.getChampionName();
+        String koChampName;
+        try {
+            // 이후 properties를 사용하여 작업을 수행합니다.
+            koChampName = (String) properties.get(engChampName);
+        } catch (Exception e) {
+            log.error("properties 파일을 읽어오는데 실패했습니다.\n" + e.getMessage() + "\n" + e.getStackTrace());
+            koChampName = engChampName;
+        }
+        return koChampName;
+    }
+}

--- a/src/main/java/com/gamemoonchul/application/converter/PostConverter.java
+++ b/src/main/java/com/gamemoonchul/application/converter/PostConverter.java
@@ -8,6 +8,7 @@ import com.gamemoonchul.infrastructure.web.dto.request.PostUploadRequest;
 import com.gamemoonchul.infrastructure.web.dto.response.CommentResponse;
 import com.gamemoonchul.infrastructure.web.dto.response.MatchUserResponse;
 import com.gamemoonchul.infrastructure.web.dto.response.PostDetailResponse;
+import com.gamemoonchul.infrastructure.web.dto.response.PostMainPageResponse;
 import com.gamemoonchul.infrastructure.web.dto.response.VoteRatioResponse;
 
 import java.util.HashMap;
@@ -95,4 +96,18 @@ public class PostConverter {
         return result;
     }
 
+    public static PostMainPageResponse entityToResponse(Post entity) {
+        List<Double> voteRatio = List.of(100 - entity.getVoteRatio(), entity.getVoteRatio());
+        return PostMainPageResponse.builder()
+            .id(entity.getId())
+            .member(MemberConverter.toResponseDto(entity.getMember()))
+            .videoUrl(entity.getVideoUrl())
+            .thumbnailUrl(entity.getThumbnailUrl())
+            .title(entity.getTitle())
+            .content(entity.getContent())
+            .viewCount(entity.getViewCount())
+            .timesAgo(StringUtils.getTimeAgo(entity.getCreatedAt()))
+            .voteRatio(voteRatio)
+            .build();
+    }
 }

--- a/src/main/java/com/gamemoonchul/application/converter/PostConverter.java
+++ b/src/main/java/com/gamemoonchul/application/converter/PostConverter.java
@@ -5,7 +5,7 @@ import com.gamemoonchul.domain.entity.Member;
 import com.gamemoonchul.domain.entity.Post;
 import com.gamemoonchul.domain.entity.redis.RedisPostDetail;
 import com.gamemoonchul.infrastructure.web.dto.request.PostUploadRequest;
-import com.gamemoonchul.infrastructure.web.dto.response.MatchGameResponse;
+import com.gamemoonchul.infrastructure.web.dto.response.MatchUserResponse;
 import com.gamemoonchul.infrastructure.web.dto.response.VoteRatioResponse;
 
 import java.util.HashMap;
@@ -68,7 +68,7 @@ public class PostConverter {
             .stream()
             .map(vo -> {
                 Double voteRatio = voteRatioMap.get(vo.getId());
-                MatchGameResponse.MatchUserResponse matchUserResponse = MatchGameResponse.MatchUserResponse.toResponseVoId(vo.getMatchUser(), vo.getId());
+                MatchUserResponse matchUserResponse = MatchUserConverter.toResponseVoId(vo.getMatchUser(), vo.getId());
                 return new VoteRatioResponse(matchUserResponse, voteRatio);
             })
             .toList();

--- a/src/main/java/com/gamemoonchul/application/converter/PostConverter.java
+++ b/src/main/java/com/gamemoonchul/application/converter/PostConverter.java
@@ -5,7 +5,9 @@ import com.gamemoonchul.domain.entity.Member;
 import com.gamemoonchul.domain.entity.Post;
 import com.gamemoonchul.domain.entity.redis.RedisPostDetail;
 import com.gamemoonchul.infrastructure.web.dto.request.PostUploadRequest;
+import com.gamemoonchul.infrastructure.web.dto.response.CommentResponse;
 import com.gamemoonchul.infrastructure.web.dto.response.MatchUserResponse;
+import com.gamemoonchul.infrastructure.web.dto.response.PostDetailResponse;
 import com.gamemoonchul.infrastructure.web.dto.response.VoteRatioResponse;
 
 import java.util.HashMap;
@@ -40,7 +42,24 @@ public class PostConverter {
             .build();
     }
 
-    private static List<VoteRatioResponse> getVoteDetail(Post post) {
+    public static PostDetailResponse toResponse(Post post, List<CommentResponse> comments) {
+        return PostDetailResponse.builder()
+            .id(post.getId())
+            .author(MemberConverter.toResponseDto(post.getMember()))
+            .videoUrl(post.getVideoUrl())
+            .thumbnailUrl(post.getThumbnailUrl())
+            .commentCount(post.getCommentCount())
+            .title(post.getTitle())
+            .content(post.getContent())
+            .timesAgo(StringUtils.getTimeAgo(post.getCreatedAt()))
+            .viewCount(post.getViewCount())
+            .comments(comments)
+            .voteDetail(getVoteDetail(post))
+            .build();
+    }
+
+
+    public static List<VoteRatioResponse> getVoteDetail(Post post) {
         HashMap<Long, Double> voteRatioMap = new HashMap<>();
         post.getVoteOptions()
             .forEach(vo -> {

--- a/src/main/java/com/gamemoonchul/application/converter/VoteConverter.java
+++ b/src/main/java/com/gamemoonchul/application/converter/VoteConverter.java
@@ -1,0 +1,14 @@
+package com.gamemoonchul.application.converter;
+
+import com.gamemoonchul.domain.entity.Vote;
+import com.gamemoonchul.infrastructure.web.dto.response.VoteResponse;
+
+public class VoteConverter {
+    public static VoteResponse entityToResponse(Vote vote) {
+        return VoteResponse.builder()
+            .id(vote.getId())
+            .postId(vote.getPost().getId())
+            .voteOptionId(vote.getVoteOption().getId())
+            .build();
+    }
+}

--- a/src/main/java/com/gamemoonchul/application/post/PostOpenApiService.java
+++ b/src/main/java/com/gamemoonchul/application/post/PostOpenApiService.java
@@ -55,7 +55,7 @@ public class PostOpenApiService {
         Page<Post> savedPage = postRepository.searchNewPostsWithoutBanPosts(requestMemberId, PageRequest.of(page, size));
         List<PostMainPageResponse> responses = savedPage.getContent()
             .stream()
-            .map(PostMainPageResponse::entityToResponse)
+            .map(PostConverter::entityToResponse)
             .collect(Collectors.toList());
 
         return new Pagination<>(savedPage, responses);
@@ -65,7 +65,7 @@ public class PostOpenApiService {
         Page<Post> savedPage = postRepository.searchGrillPostsWithoutBanPosts(requestMemberId, PageRequest.of(page, size));
         List<PostMainPageResponse> responses = savedPage.getContent()
             .stream()
-            .map(PostMainPageResponse::entityToResponse)
+            .map(PostConverter::entityToResponse)
             .toList();
         return new Pagination<PostMainPageResponse>(savedPage, responses);
     }
@@ -75,7 +75,7 @@ public class PostOpenApiService {
 
         List<PostMainPageResponse> responses = savedPage.getContent()
             .stream()
-            .map(PostMainPageResponse::entityToResponse)
+            .map(PostConverter::entityToResponse)
             .toList();
         return new Pagination<>(savedPage, responses);
     }

--- a/src/main/java/com/gamemoonchul/application/post/PostOpenApiService.java
+++ b/src/main/java/com/gamemoonchul/application/post/PostOpenApiService.java
@@ -1,6 +1,7 @@
 package com.gamemoonchul.application.post;
 
 import com.gamemoonchul.application.CommentService;
+import com.gamemoonchul.application.converter.CommentConverter;
 import com.gamemoonchul.application.converter.PostConverter;
 import com.gamemoonchul.common.exception.BadRequestException;
 import com.gamemoonchul.domain.entity.Post;
@@ -44,7 +45,7 @@ public class PostOpenApiService {
         }
 
         List<CommentResponse> comments = commentService.searchByPostId(redisPostDetail.getId(), requestMemberId).stream()
-            .map(CommentResponse::entityToResponse).toList(); // 변경 자주 일어남, 캐싱 X
+            .map(CommentConverter::toResponse).toList(); // 변경 자주 일어남, 캐싱 X
         redisPostDetail.setComments(comments);
 
         return redisPostDetail;

--- a/src/main/java/com/gamemoonchul/application/post/PostService.java
+++ b/src/main/java/com/gamemoonchul/application/post/PostService.java
@@ -39,7 +39,7 @@ public class PostService {
 
         saveVoteOptions(request.matchUserIds(), savedPost);
 
-        return PostDetailResponse.toResponse(savedPost, Collections.emptyList());
+        return PostConverter.toResponse(savedPost, Collections.emptyList());
     }
 
     private void saveVoteOptions(List<Long> matchUserIds, Post post) {

--- a/src/main/java/com/gamemoonchul/common/util/PropertyUtil.java
+++ b/src/main/java/com/gamemoonchul/common/util/PropertyUtil.java
@@ -1,0 +1,28 @@
+package com.gamemoonchul.common.util;
+
+import com.gamemoonchul.infrastructure.web.dto.response.MatchUserResponse;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+@Slf4j
+public class PropertyUtil {
+    public static Properties loadProperties() {
+        Properties properties = new Properties();
+        try {
+            InputStream inputStream = MatchUserResponse.class.getClassLoader()
+                .getResourceAsStream("lolchampion.properties");
+            InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+            properties = new Properties();
+            properties.load(reader);
+        } catch (IOException e) {
+            log.error("properties 파일을 읽어오는데 실패했습니다.\n" + e.getMessage() + "\n" + e.getStackTrace());
+        }
+        return properties;
+    }
+
+}

--- a/src/main/java/com/gamemoonchul/infrastructure/web/PostBanApiController.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/PostBanApiController.java
@@ -1,6 +1,7 @@
 package com.gamemoonchul.infrastructure.web;
 
 import com.gamemoonchul.application.PostBanService;
+import com.gamemoonchul.application.converter.PostConverter;
 import com.gamemoonchul.common.annotation.MemberSession;
 import com.gamemoonchul.domain.entity.Member;
 import com.gamemoonchul.domain.entity.PostBan;
@@ -22,18 +23,18 @@ public class PostBanApiController {
 
     @GetMapping("/ban")
     public List<PostMainPageResponse> getBannedPosts(
-            @MemberSession Member member
+        @MemberSession Member member
     ) {
         return postBanService.bannedPost(member.getId()).stream()
-                .map(PostBan::getBanPost)
-                .map(PostMainPageResponse::entityToResponse)
-                .toList();
+            .map(PostBan::getBanPost)
+            .map(PostConverter::entityToResponse)
+            .toList();
     }
 
     @PostMapping("/ban/{postId}")
     public void ban(
-            @MemberSession Member member,
-            @PathVariable(name = "postId") Long postId
+        @MemberSession Member member,
+        @PathVariable(name = "postId") Long postId
     ) {
         postBanService.ban(member, postId);
     }

--- a/src/main/java/com/gamemoonchul/infrastructure/web/VoteController.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/VoteController.java
@@ -1,6 +1,7 @@
 package com.gamemoonchul.infrastructure.web;
 
 import com.gamemoonchul.application.VoteService;
+import com.gamemoonchul.application.converter.VoteConverter;
 import com.gamemoonchul.common.annotation.MemberSession;
 import com.gamemoonchul.domain.entity.Member;
 import com.gamemoonchul.domain.entity.Vote;
@@ -23,10 +24,10 @@ public class VoteController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public VoteResponse save(
-            @RequestBody VoteCreateRequest voteCreateRequest,
-            @MemberSession Member member
+        @RequestBody VoteCreateRequest voteCreateRequest,
+        @MemberSession Member member
     ) {
         Vote vote = voteService.createVote(voteCreateRequest, member);
-        return VoteResponse.entityToResponse(vote);
+        return VoteConverter.entityToResponse(vote);
     }
 }

--- a/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/CommentResponse.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/CommentResponse.java
@@ -1,28 +1,12 @@
 package com.gamemoonchul.infrastructure.web.dto.response;
 
-import com.gamemoonchul.application.converter.MemberConverter;
-import com.gamemoonchul.common.util.StringUtils;
-import com.gamemoonchul.domain.entity.Comment;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CommentResponse {
-    private MemberResponse author;
-    private String content;
-    private String timesAgo;
+public record CommentResponse(
+    MemberResponse author,
+    String content,
+    String timesAgo
+) {
 
-    public static CommentResponse entityToResponse(Comment entity) {
-        return CommentResponse.builder()
-            .author(MemberConverter.toResponseDto(entity.getMember()))
-            .content(entity.getContent())
-            .timesAgo(StringUtils.getTimeAgo(entity.getCreatedAt()))
-            .build();
-    }
 }

--- a/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/MatchGameResponse.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/MatchGameResponse.java
@@ -1,111 +1,15 @@
 package com.gamemoonchul.infrastructure.web.dto.response;
 
-import com.gamemoonchul.domain.entity.riot.MatchGame;
-import com.gamemoonchul.domain.entity.riot.MatchUser;
-import lombok.*;
-import lombok.extern.slf4j.Slf4j;
+import lombok.Builder;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Properties;
 
-@Getter
 @Builder
-@Slf4j
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-public class MatchGameResponse {
-    private String gameId;
-    private String gameCreation;
-    private long gameDuration;
-    private String gameMode;
-    private List<MatchUserResponse> matchUsers;
-
-    public static MatchGameResponse toResponse(MatchGame matchGame) {
-        Properties properties = loadProperties();
-        return MatchGameResponse.builder()
-            .gameId(matchGame.getGameId())
-            .gameCreation(matchGame.getGameCreation())
-            .gameDuration(matchGame.getGameDuration())
-            .gameMode(matchGame.getGameMode())
-            .matchUsers(matchGame.getMatchUsers()
-                .stream()
-                .map(MatchUserResponse::toResponse)
-                .toList())
-            .build();
-    }
-
-    public static Properties loadProperties() {
-        Properties properties = new Properties();
-        try {
-            InputStream inputStream = MatchUserResponse.class.getClassLoader()
-                .getResourceAsStream("lolchampion.properties");
-            InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-            properties = new Properties();
-            properties.load(reader);
-        } catch (IOException e) {
-            log.error("properties 파일을 읽어오는데 실패했습니다.\n" + e.getMessage() + "\n" + e.getStackTrace());
-        }
-        return properties;
-    }
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class MatchUserResponse {
-        private Long id;
-        private String nickname;
-        private String championName;
-        private String championThumbnail;
-        private boolean win;
-
-        public static MatchUserResponse toResponse(MatchUser matchUser) {
-            String koChampName = getKoChampName(loadProperties(), matchUser);
-
-            return MatchUserResponse.builder()
-                .id(matchUser.getId())
-                .nickname(matchUser.getNickname())
-                .championName(koChampName)
-                .championThumbnail(getChampThumbnail(matchUser.getChampionName()))
-                .win(matchUser.isWin())
-                .build();
-        }
-
-        /**
-         * @param matchUser "VoteOption"의 "MatchUser"
-         * @param voId      "VoteOption의 ID"
-         */
-        public static MatchUserResponse toResponseVoId(MatchUser matchUser, Long voId) {
-            String koChampName = getKoChampName(loadProperties(), matchUser);
-
-            return MatchUserResponse.builder()
-                .id(voId)
-                .nickname(matchUser.getNickname())
-                .championName(koChampName)
-                .championThumbnail(getChampThumbnail(matchUser.getChampionName()))
-                .win(matchUser.isWin())
-                .build();
-        }
-
-        public static String getChampThumbnail(String championName) {
-            return "https://ddragon.leagueoflegends.com/cdn/img/champion/splash/" + championName + "_0.jpg";
-        }
-
-        private static String getKoChampName(Properties properties, MatchUser matchUser) {
-            String engChampName = matchUser.getChampionName();
-            String koChampName;
-            try {
-                // 이후 properties를 사용하여 작업을 수행합니다.
-                koChampName = (String) properties.get(engChampName);
-            } catch (Exception e) {
-                log.error("properties 파일을 읽어오는데 실패했습니다.\n" + e.getMessage() + "\n" + e.getStackTrace());
-                koChampName = engChampName;
-            }
-            return koChampName;
-        }
-    }
+public record MatchGameResponse(
+    String gameId,
+    String gameCreation,
+    long gameDuration,
+    String gameMode,
+    List<MatchUserResponse> matchUsers
+) {
 }

--- a/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/MatchUserResponse.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/MatchUserResponse.java
@@ -1,0 +1,13 @@
+package com.gamemoonchul.infrastructure.web.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record MatchUserResponse(
+    Long id,
+    String nickname,
+    String championName,
+    String championThumbnail,
+    boolean win
+) {
+}

--- a/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/MemberResponse.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/MemberResponse.java
@@ -1,18 +1,16 @@
 package com.gamemoonchul.infrastructure.web.dto.response;
 
-import lombok.*;
+import lombok.Builder;
 
-@Getter
-@Setter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-public class MemberResponse {
-    private Long id;
-    private String name;
-    private String nickname;
-    private String email;
-    private String picture;
-    private boolean privacyAgreed;
-    private Double score;
+public record MemberResponse(
+    Long id,
+    String name,
+    String nickname,
+    String email,
+    String picture,
+    boolean privacyAgreed,
+    Double score
+) {
+
 }

--- a/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/PostDetailResponse.java
@@ -1,15 +1,9 @@
 package com.gamemoonchul.infrastructure.web.dto.response;
 
-import com.gamemoonchul.application.converter.MatchUserConverter;
-import com.gamemoonchul.application.converter.MemberConverter;
-import com.gamemoonchul.common.util.StringUtils;
-import com.gamemoonchul.domain.entity.Post;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
 
 @Getter
 @Builder
@@ -25,76 +19,4 @@ public class PostDetailResponse {
     private Long commentCount;
     private List<CommentResponse> comments;
     private List<VoteRatioResponse> voteDetail;
-
-    public static PostDetailResponse toResponse(Post post) {
-        return PostDetailResponse.builder()
-            .id(post.getId())
-            .author(MemberConverter.toResponseDto(post.getMember()))
-            .videoUrl(post.getVideoUrl())
-            .thumbnailUrl(post.getThumbnailUrl())
-            .commentCount(post.getCommentCount())
-            .title(post.getTitle())
-            .content(post.getContent())
-            .timesAgo(StringUtils.getTimeAgo(post.getCreatedAt()))
-            .viewCount(post.getViewCount())
-            .voteDetail(getVoteDetail(post))
-            .build();
-    }
-
-    public static PostDetailResponse toResponse(Post post, List<CommentResponse> comments) {
-        return PostDetailResponse.builder()
-            .id(post.getId())
-            .author(MemberConverter.toResponseDto(post.getMember()))
-            .videoUrl(post.getVideoUrl())
-            .thumbnailUrl(post.getThumbnailUrl())
-            .commentCount(post.getCommentCount())
-            .title(post.getTitle())
-            .content(post.getContent())
-            .timesAgo(StringUtils.getTimeAgo(post.getCreatedAt()))
-            .viewCount(post.getViewCount())
-            .comments(comments)
-            .voteDetail(getVoteDetail(post))
-            .build();
-    }
-
-
-    public static List<VoteRatioResponse> getVoteDetail(Post post) {
-        HashMap<Long, Double> voteRatioMap = new HashMap<>();
-        post.getVoteOptions()
-            .forEach(vo -> {
-                voteRatioMap.put(vo.getId(), 0.0);
-                Optional.ofNullable(vo.getVotes())
-                    .ifPresent(votes -> {
-                        votes.forEach(v -> voteRatioMap.put(v.getId(), 0.0));
-                    });
-            });
-
-        Double totalVoteCnt = voteRatioMap.values()
-            .stream()
-            .mapToDouble(Double::doubleValue)
-            .sum();
-
-        voteRatioMap.forEach((k, v) -> {
-            if (totalVoteCnt == 0) {
-                voteRatioMap.put(k, 0.0);
-            } else {
-                voteRatioMap.put(k, (v / totalVoteCnt) * 100);
-            }
-        });
-
-        List<VoteRatioResponse> result = post.getVoteOptions()
-            .stream()
-            .map(vo -> {
-                Double voteRatio = voteRatioMap.get(vo.getId());
-                MatchUserResponse matchUserResponse = MatchUserConverter.toResponseVoId(vo.getMatchUser(), vo.getId());
-                return new VoteRatioResponse(matchUserResponse, voteRatio);
-            })
-            .toList();
-
-        return result;
-    }
-
-    public void setComments(List<CommentResponse> comments) {
-        this.comments = comments;
-    }
 }

--- a/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/PostDetailResponse.java
@@ -1,5 +1,6 @@
 package com.gamemoonchul.infrastructure.web.dto.response;
 
+import com.gamemoonchul.application.converter.MatchUserConverter;
 import com.gamemoonchul.application.converter.MemberConverter;
 import com.gamemoonchul.common.util.StringUtils;
 import com.gamemoonchul.domain.entity.Post;
@@ -85,7 +86,7 @@ public class PostDetailResponse {
             .stream()
             .map(vo -> {
                 Double voteRatio = voteRatioMap.get(vo.getId());
-                MatchGameResponse.MatchUserResponse matchUserResponse = MatchGameResponse.MatchUserResponse.toResponseVoId(vo.getMatchUser(), vo.getId());
+                MatchUserResponse matchUserResponse = MatchUserConverter.toResponseVoId(vo.getMatchUser(), vo.getId());
                 return new VoteRatioResponse(matchUserResponse, voteRatio);
             })
             .toList();

--- a/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/PostDetailResponse.java
@@ -1,22 +1,22 @@
 package com.gamemoonchul.infrastructure.web.dto.response;
 
 import lombok.Builder;
-import lombok.Getter;
 
 import java.util.List;
 
-@Getter
 @Builder
-public class PostDetailResponse {
-    private Long id;
-    private MemberResponse author;
-    private String videoUrl;
-    private String thumbnailUrl;
-    private String title;
-    private String content;
-    private String timesAgo;
-    private Long viewCount;
-    private Long commentCount;
-    private List<CommentResponse> comments;
-    private List<VoteRatioResponse> voteDetail;
+public record PostDetailResponse(
+    Long id,
+    MemberResponse author,
+    String videoUrl,
+    String thumbnailUrl,
+    String title,
+    String content,
+    String timesAgo,
+    Long viewCount,
+    Long commentCount,
+    List<CommentResponse> comments,
+    List<VoteRatioResponse> voteDetail
+) {
+
 }

--- a/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/PostMainPageResponse.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/PostMainPageResponse.java
@@ -1,44 +1,20 @@
 package com.gamemoonchul.infrastructure.web.dto.response;
 
-import com.gamemoonchul.application.converter.MemberConverter;
-import com.gamemoonchul.common.util.StringUtils;
-import com.gamemoonchul.domain.entity.Post;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.List;
 
-@Getter
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PostMainPageResponse {
-    private Long id;
-    private MemberResponse member;
-    private String videoUrl;
-    private String thumbnailUrl;
-    private String title;
-    private String content;
-    private String timesAgo;
-    private Long viewCount;
-    private List<Double> voteRatio;
-
-    public static PostMainPageResponse entityToResponse(Post entity) {
-        List<Double> voteRatio = List.of(100 - entity.getVoteRatio(), entity.getVoteRatio());
-        return PostMainPageResponse.builder()
-            .id(entity.getId())
-            .member(MemberConverter.toResponseDto(entity.getMember()))
-            .videoUrl(entity.getVideoUrl())
-            .thumbnailUrl(entity.getThumbnailUrl())
-            .title(entity.getTitle())
-            .content(entity.getContent())
-            .viewCount(entity.getViewCount())
-            .timesAgo(StringUtils.getTimeAgo(entity.getCreatedAt()))
-            .voteRatio(voteRatio)
-            .build();
-    }
+public record PostMainPageResponse(
+    Long id,
+    MemberResponse member,
+    String videoUrl,
+    String thumbnailUrl,
+    String title,
+    String content,
+    String timesAgo,
+    Long viewCount,
+    List<Double> voteRatio
+) {
 
 }

--- a/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/VoteRatioResponse.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/VoteRatioResponse.java
@@ -1,16 +1,11 @@
 package com.gamemoonchul.infrastructure.web.dto.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
 @Builder
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class VoteRatioResponse {
-    private MatchUserResponse matchUserResponse;
-    private Double voteRatio;
+public record VoteRatioResponse(
+    MatchUserResponse matchUserResponse,
+    Double voteRatio
+) {
+
 }

--- a/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/VoteRatioResponse.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/VoteRatioResponse.java
@@ -11,6 +11,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class VoteRatioResponse {
-    private MatchGameResponse.MatchUserResponse matchUserResponse;
+    private MatchUserResponse matchUserResponse;
     private Double voteRatio;
 }

--- a/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/VoteResponse.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/VoteResponse.java
@@ -1,21 +1,12 @@
 package com.gamemoonchul.infrastructure.web.dto.response;
 
-import com.gamemoonchul.domain.entity.Vote;
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
 @Builder
-public class VoteResponse {
-    private Long id;
-    private Long postId;
-    private Long voteOptionId;
+public record VoteResponse(
+    Long id,
+    Long postId,
+    Long voteOptionId
+) {
 
-    public static VoteResponse entityToResponse(Vote vote) {
-        return VoteResponse.builder()
-                .id(vote.getId())
-                .postId(vote.getPost().getId())
-                .voteOptionId(vote.getVoteOption().getId())
-                .build();
-    }
 }

--- a/src/test/java/com/gamemoonchul/application/PostOpenApiServiceTest.java
+++ b/src/test/java/com/gamemoonchul/application/PostOpenApiServiceTest.java
@@ -31,8 +31,7 @@ class PostOpenApiServiceTest extends TestDataBase {
         memberRepository.save(member);
         ArrayList<Post> posts = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
-            Post dummy = PostDummy.createPost("value" + i);
-            dummy.setMember(member);
+            Post dummy = PostDummy.createPost("value" + 1, member);
             posts.add(dummy);
         }
         postRepository.saveAll(posts);

--- a/src/test/java/com/gamemoonchul/domain/entity/PostDummy.java
+++ b/src/test/java/com/gamemoonchul/domain/entity/PostDummy.java
@@ -10,45 +10,56 @@ import java.util.List;
 public class PostDummy {
     public static PostUploadRequest createRequest() {
         return PostUploadRequest.builder()
-                .title("string")
-                .content("string")
-                .videoUrl("https://youtube.com/")
-                .thumbnailUrl("https://s3/")
-                .matchUserIds(new ArrayList<>())
-                .build();
+            .title("string")
+            .content("string")
+            .videoUrl("https://youtube.com/")
+            .thumbnailUrl("https://s3/")
+            .matchUserIds(new ArrayList<>())
+            .build();
     }
 
     public static PostUploadRequest createRequest(List<Long> matchUserIds) {
         return PostUploadRequest.builder()
-                .title("string")
-                .content("string")
-                .videoUrl("https://youtube.com/")
-                .thumbnailUrl("https://s3/")
-                .matchUserIds(matchUserIds)
-                .build();
+            .title("string")
+            .content("string")
+            .videoUrl("https://youtube.com/")
+            .thumbnailUrl("https://s3/")
+            .matchUserIds(matchUserIds)
+            .build();
     }
 
 
     public static Post createPost(String value) {
         Post post = Post.builder()
-                .title(value)
-                .content(value)
-                .videoUrl("https://youtube.com")
-                .thumbnailUrl("https://s3.amazon.com")
-                .build();
+            .title(value)
+            .content(value)
+            .videoUrl("https://youtube.com")
+            .thumbnailUrl("https://s3.amazon.com")
+            .build();
         return post;
     }
 
+    public static Post createPost(String value, Member member) {
+        Post post = Post.builder()
+            .title(value)
+            .content(value)
+            .videoUrl("https://youtube.com")
+            .thumbnailUrl("https://s3.amazon.com")
+            .build();
+        return post;
+    }
+
+
     public static Post createPostWithSpecificMember(Member member) {
         Post post = Post.builder()
-                .title("제목")
-                .member(member)
-                .content("내용")
-                .videoUrl("https://youtube.com")
-                .thumbnailUrl("https://s3.amazon.com")
-                .voteOptions(VoteOptionsDummy.createVoteOptionsEmptyVote())
-                .createdAt(LocalDateTime.now())
-                .build();
+            .title("제목")
+            .member(member)
+            .content("내용")
+            .videoUrl("https://youtube.com")
+            .thumbnailUrl("https://s3.amazon.com")
+            .voteOptions(VoteOptionsDummy.createVoteOptionsEmptyVote())
+            .createdAt(LocalDateTime.now())
+            .build();
         return post;
     }
 }

--- a/src/test/java/com/gamemoonchul/infrastructure/web/dto/MatchGameResponseTest.java
+++ b/src/test/java/com/gamemoonchul/infrastructure/web/dto/MatchGameResponseTest.java
@@ -1,6 +1,7 @@
 package com.gamemoonchul.infrastructure.web.dto;
 
 import com.gamemoonchul.TestDataBase;
+import com.gamemoonchul.application.converter.MatchGameConverter;
 import com.gamemoonchul.domain.entity.riot.MatchGame;
 import com.gamemoonchul.domain.entity.riot.MatchGameDummy;
 import com.gamemoonchul.infrastructure.web.dto.response.MatchGameResponse;
@@ -17,15 +18,15 @@ class MatchGameResponseTest extends TestDataBase {
         MatchGame matchGame = MatchGameDummy.create();
 
         // when
-        MatchGameResponse matchGameResponse = MatchGameResponse.toResponse(matchGame);
+        MatchGameResponse matchGameResponse = MatchGameConverter.toResponse(matchGame);
 
         // then
-        assertEquals(matchGame.getGameCreation(), matchGameResponse.getGameCreation());
-        assertEquals(matchGame.getGameMode(), matchGameResponse.getGameMode());
-        assertEquals(matchGame.getGameDuration(), matchGameResponse.getGameDuration());
+        assertEquals(matchGame.getGameCreation(), matchGameResponse.gameCreation());
+        assertEquals(matchGame.getGameMode(), matchGameResponse.gameMode());
+        assertEquals(matchGame.getGameDuration(), matchGameResponse.gameDuration());
         assertEquals(matchGame.getMatchUsers()
-                .size(), matchGameResponse.getMatchUsers()
-                .size());
+            .size(), matchGameResponse.matchUsers()
+            .size());
     }
 
 }


### PR DESCRIPTION
## Related Issue

Related to : #194

## Reference 

- [앞선 PR](https://github.com/gamemuncheol/gamemuncheol-api/pull/195)에서 한 논의대로 Converter 분리 
- 근거 1 : Entity가 화면에 의존적이게 될 수 있다. 
- 근거 2 : 도메인 로직(고수준)이 Presentation Layer(저수준)의 DTO에 의존적이게 된다.