### PR TITLE
Nickname 변경 api query param -> request body로 변경

### DIFF
--- a/src/main/java/com/gamemoonchul/application/member/MemberService.java
+++ b/src/main/java/com/gamemoonchul/application/member/MemberService.java
@@ -6,9 +6,9 @@ import com.gamemoonchul.config.oauth.user.OAuth2Provider;
 import com.gamemoonchul.domain.entity.Member;
 import com.gamemoonchul.domain.status.MemberStatus;
 import com.gamemoonchul.infrastructure.repository.MemberRepository;
+import com.gamemoonchul.infrastructure.web.dto.request.NicknameChangeRequest;
 import com.gamemoonchul.infrastructure.web.dto.response.MemberResponse;
 import jakarta.transaction.Transactional;
-import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,11 +33,11 @@ public class MemberService {
         return memberRepository.findByProviderAndIdentifier(provider, identifier);
     }
 
-    public void updateNickName(Member member, @Size(max = 10) String nickName) {
-        if (isExistNickname(nickName)) {
+    public void updateNickName(Member member, NicknameChangeRequest request) {
+        if (isExistNickname(request.nickname())) {
             throw new BadRequestException(MemberStatus.ALREADY_EXIST_NICKNAME);
         }
-        Member updatedMember = member.updateNickname(nickName);
+        Member updatedMember = member.updateNickname(request.nickname());
         memberRepository.save(updatedMember);
     }
 

--- a/src/main/java/com/gamemoonchul/domain/entity/Post.java
+++ b/src/main/java/com/gamemoonchul/domain/entity/Post.java
@@ -17,7 +17,8 @@ import java.util.List;
 @Table(name = "post", indexes = {
     @Index(name = "idx_vote_ratio_vote_count", columnList = "vote_ratio DESC, vote_count DESC"),
     @Index(name = "idx_post_created_at_desc", columnList = "created_at DESC"),
-    @Index(name = "idx_view_count", columnList = "view_count DESC")
+    @Index(name = "idx_view_count", columnList = "view_count DESC"),
+    @Index(name = "idx_member_id", columnList = "member_id")
 })
 public class Post extends BaseTimeEntity {
     @Id

--- a/src/main/java/com/gamemoonchul/domain/entity/VoteOptions.java
+++ b/src/main/java/com/gamemoonchul/domain/entity/VoteOptions.java
@@ -14,20 +14,17 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class VoteOptions {
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "voteOption", cascade = CascadeType.ALL, orphanRemoval = true)
+    final private List<Vote> votes = new ArrayList<>();
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
-
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "match_user_id")
     private MatchUser matchUser;
-
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "voteOption", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Vote> votes = new ArrayList<>();
 
     public void addVote(Vote vote) {
         this.votes.add(vote);

--- a/src/main/java/com/gamemoonchul/infrastructure/web/MemberApiController.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/MemberApiController.java
@@ -7,6 +7,7 @@ import com.gamemoonchul.common.annotation.MemberSession;
 import com.gamemoonchul.domain.entity.Member;
 import com.gamemoonchul.domain.entity.MemberBan;
 import com.gamemoonchul.infrastructure.web.common.RestControllerWithEnvelopPattern;
+import com.gamemoonchul.infrastructure.web.dto.request.NicknameChangeRequest;
 import com.gamemoonchul.infrastructure.web.dto.response.MemberResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -20,12 +21,12 @@ public class MemberApiController {
     private final MemberService memberService;
     private final MemberBanService memberBanService;
 
-    @PatchMapping("/nickname/{nickname}")
+    @PatchMapping("/nickname")
     public void changeNickname(
         @MemberSession Member member,
-        @PathVariable(name = "nickname") String nickname
+        @RequestBody NicknameChangeRequest request
     ) {
-        memberService.updateNickName(member, nickname);
+        memberService.updateNickName(member, request);
     }
 
 

--- a/src/main/java/com/gamemoonchul/infrastructure/web/MemberOpenApiController.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/MemberOpenApiController.java
@@ -19,9 +19,9 @@ public class MemberOpenApiController {
         return memberOpenApiService.renew(request.refreshToken());
     }
 
-    @GetMapping("/nickname/{nickname}")
+    @GetMapping("/duplicated/nicknames")
     public boolean checkNicknameDuplicated(
-            @PathVariable(name = "nickname") String nickname
+        @RequestParam(name = "nickname") String nickname
     ) {
         return memberOpenApiService.isExistNickname(nickname);
     }

--- a/src/main/java/com/gamemoonchul/infrastructure/web/dto/request/NicknameChangeRequest.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/dto/request/NicknameChangeRequest.java
@@ -1,0 +1,9 @@
+package com.gamemoonchul.infrastructure.web.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record NicknameChangeRequest(
+    @Size(max = 10)
+    String nickname
+) {
+}

--- a/src/main/resources/db/migration/V4__add_member_id_idx_to_post.sql
+++ b/src/main/resources/db/migration/V4__add_member_id_idx_to_post.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_member_id
+    ON post (member_id);

--- a/src/test/java/com/gamemoonchul/application/MemberServiceTest.java
+++ b/src/test/java/com/gamemoonchul/application/MemberServiceTest.java
@@ -7,6 +7,7 @@ import com.gamemoonchul.domain.entity.Member;
 import com.gamemoonchul.domain.entity.MemberDummy;
 import com.gamemoonchul.domain.status.MemberStatus;
 import com.gamemoonchul.infrastructure.repository.MemberRepository;
+import com.gamemoonchul.infrastructure.web.dto.request.NicknameChangeRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,15 +32,15 @@ class MemberServiceTest extends TestDataBase {
         // given
         Member member = MemberDummy.create();
         memberRepository.save(member);
-        String nickname = "우하하";
+        NicknameChangeRequest request = new NicknameChangeRequest("우하하");
 
         // when
-        memberService.updateNickName(member, nickname);
-        Optional<Member> savedMember = memberRepository.findByNickname(nickname);
+        memberService.updateNickName(member, request);
+        Optional<Member> savedMember = memberRepository.findByNickname(request.nickname());
 
         // then
         assertThat(savedMember.get()
-                .getNickname()).isEqualTo(nickname);
+            .getNickname()).isEqualTo(request.nickname());
     }
 
     @Test
@@ -48,14 +49,14 @@ class MemberServiceTest extends TestDataBase {
         // given
         Member member = MemberDummy.create();
         memberRepository.save(member);
-        String nickname = "우하하";
+        NicknameChangeRequest request = new NicknameChangeRequest("우하하");
 
         // when
-        memberService.updateNickName(member, nickname);
+        memberService.updateNickName(member, request);
 
         // then
-        assertThatThrownBy(() -> memberService.updateNickName(member, nickname))
-                .isInstanceOf(BadRequestException.class)
-                .hasMessageContaining(MemberStatus.ALREADY_EXIST_NICKNAME.getMessage());
+        assertThatThrownBy(() -> memberService.updateNickName(member, request))
+            .isInstanceOf(BadRequestException.class)
+            .hasMessageContaining(MemberStatus.ALREADY_EXIST_NICKNAME.getMessage());
     }
 }

--- a/src/test/java/com/gamemoonchul/application/PostDeleteServiceTest.java
+++ b/src/test/java/com/gamemoonchul/application/PostDeleteServiceTest.java
@@ -48,7 +48,7 @@ class PostDeleteServiceTest extends TestDataBase {
         PostDetailResponse response = postService.upload(PostDummy.createRequest(), member1);
 
         // then
-        assertThatThrownBy(() -> postDeleteService.delete(response.getId(), member2.getId())).isInstanceOf(UnauthorizedException.class)
+        assertThatThrownBy(() -> postDeleteService.delete(response.id(), member2.getId())).isInstanceOf(UnauthorizedException.class)
             .hasMessageContaining(PostStatus.UNAUTHORIZED_REQUEST.getMessage());
     }
 
@@ -59,13 +59,13 @@ class PostDeleteServiceTest extends TestDataBase {
         // given
         Member member = memberRepository.save(MemberDummy.create());
         PostDetailResponse response = postService.upload(PostDummy.createRequest(), member);
-        Post savedPost = postRepository.findById(response.getId())
+        Post savedPost = postRepository.findById(response.id())
             .orElseThrow(() -> new BadRequestException(PostStatus.POST_NOT_FOUND));
         Comment comment = CommentDummy.create(savedPost, member);
         commentRepository.save(comment);
 
         // when
-        postDeleteService.delete(response.getId(), member.getId());
+        postDeleteService.delete(response.id(), member.getId());
 
         // then
         assertThat(commentRepository.findAllByPost(savedPost)

--- a/src/test/java/com/gamemoonchul/application/PostServiceTest.java
+++ b/src/test/java/com/gamemoonchul/application/PostServiceTest.java
@@ -53,10 +53,10 @@ class PostServiceTest extends TestDataBase {
 
         // then
         assertThat(allSavedPost.size()).isEqualTo(1);
-        assertThat(response.getTimesAgo()).isNotNull();
+        assertThat(response.timesAgo()).isNotNull();
         assertThat(response).isNotNull();
-        assertThat(response.getVoteDetail()
+        assertThat(response.voteDetail()
             .size()).isEqualTo(2);
-        assertThat(response.getViewCount()).isEqualTo(0);
+        assertThat(response.viewCount()).isEqualTo(0);
     }
 }

--- a/src/test/java/com/gamemoonchul/infrastructure/web/MemberApiControllerTest.java
+++ b/src/test/java/com/gamemoonchul/infrastructure/web/MemberApiControllerTest.java
@@ -5,6 +5,7 @@ import com.gamemoonchul.config.jwt.*;
 import com.gamemoonchul.domain.entity.Member;
 import com.gamemoonchul.domain.entity.MemberDummy;
 import com.gamemoonchul.infrastructure.repository.MemberRepository;
+import com.gamemoonchul.infrastructure.web.dto.request.NicknameChangeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,10 +40,10 @@ class MemberApiControllerTest extends TestDataBase {
     @DisplayName("닉네임 변경 테스트")
     void nicknameChangeTest() throws Exception {
         // given
-        String nickname = UUID.randomUUID().toString().substring(0, 8);
+        NicknameChangeRequest request = new NicknameChangeRequest(UUID.randomUUID().toString().substring(0, 8));
 
         // when
-        ResultActions resultActions = super.mvc.perform(patch("/api/members/nickname/" + nickname).header("Authorization", "Bearer " + tokenDto.getAccessToken()));
+        ResultActions resultActions = super.mvc.perform(patch("/api/members/nickname").header("Authorization", "Bearer " + tokenDto.getAccessToken()).content(super.objectMapper.writeValueAsString(request)).contentType("application/json"));
 
         // then
         resultActions.andExpect(status().isOk());


### PR DESCRIPTION
## Related Issue

Related to : #194

## Overview

- Post에 member id idx 
- 닉네임 변경 api query param -> request body로 변경
- 테스트 코드에서 record 전환에 따른 get방식 변경
