### PR TITLE
Pagination 성능 개선

### DIFF
--- a/src/main/java/com/gamemoonchul/infrastructure/repository/impl/PostRepositoryImpl.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/repository/impl/PostRepositoryImpl.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 
-import static com.gamemoonchul.domain.entity.QComment.comment;
 import static com.gamemoonchul.domain.entity.QMember.member;
 import static com.gamemoonchul.domain.entity.QMemberBan.memberBan;
 import static com.gamemoonchul.domain.entity.QPost.post;
@@ -80,15 +79,6 @@ public class PostRepositoryImpl implements PostRepositoryIfs {
             .fetch();
 
         return new PageImpl<>(content, pageable, total);
-    }
-
-    public List<Post> searchByPostIdWithComment(Long postId) {
-        JPAQuery<Post> query = queryFactory.selectFrom(post)
-            .where(post.id.eq(postId))
-            .leftJoin(post, comment.post)
-            .on(post.id.eq(comment.post.id))
-            .fetchJoin();
-        return query.fetch();
     }
 
     @Override


### PR DESCRIPTION
## Related Issue

Related to : #199 

## Overview

- member fetch join 및 total count 쿼리 분리로 전체 데이터 조회하는 쿼리 개선

## Result 

- hot api 응답 속도 `368ms -> 332ms`

- new 개선전

```sql
SELECT * FROM post p1_0 JOIN member m1_0 ON m1_0.id = p1_0.member_id 
ORDER BY p1_0.created_at DESC LIMIT ?, ?;
SELECT * FROM post p1_0 JOIN member m1_0 ON m1_0.id = p1_0.member_id 
ORDER BY p1_0.created_at DESC LIMIT ?, ?;
```

- new 개선후

```sql
SELECT COUNT(p1_0.id) FROM post p1_0;

SELECT * FROM post p1_0 JOIN member m1_0 ON m1_0.id = p1_0.member_id
ORDER BY p1_0.created_at DESC LIMIT ?, ?;
```