### PR TITLE
댓글 카운트 캐시에 작성하고 Cache Aside Pattern으로 가져오도록 변경

### DIFF
--- a/src/main/java/com/gamemoonchul/application/PostBanService.java
+++ b/src/main/java/com/gamemoonchul/application/PostBanService.java
@@ -1,14 +1,20 @@
 package com.gamemoonchul.application;
 
+import com.gamemoonchul.application.converter.PostConverter;
 import com.gamemoonchul.application.post.PostService;
 import com.gamemoonchul.domain.entity.Member;
 import com.gamemoonchul.domain.entity.Post;
 import com.gamemoonchul.domain.entity.PostBan;
+import com.gamemoonchul.infrastructure.repository.CommentRepository;
 import com.gamemoonchul.infrastructure.repository.PostBanRepository;
+import com.gamemoonchul.infrastructure.web.dto.response.PostMainPageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 
 @Service
@@ -16,17 +22,30 @@ import java.util.List;
 public class PostBanService {
     private final PostBanRepository postBanRepository;
     private final PostService postService;
+    private final CommentRepository commentRepository;
+    private final ExecutorService executor = Executors.newFixedThreadPool(10);
 
     public void ban(Member member, Long postId) {
         Post post = postService.findById(postId);
         PostBan postBan = PostBan.builder()
-                .banPost(post)
-                .member(member)
-                .build();
+            .banPost(post)
+            .member(member)
+            .build();
         postBanRepository.save(postBan);
     }
 
-    public List<PostBan> bannedPost(Long id) {
-        return postBanRepository.searchByMemberId(id);
+    public List<PostMainPageResponse> bannedPostList(Long id) {
+        List<CompletableFuture<PostMainPageResponse>> futures = postBanRepository.searchByMemberId(id)
+            .stream()
+            .map(PostBan::getBanPost)
+            .map(post -> CompletableFuture.supplyAsync(() -> {
+                Integer commentCount = commentRepository.countByPostId(post.getId());
+                return PostConverter.entityToResponse(post, commentCount);
+            }, executor))
+            .toList();
+
+        return futures.stream()
+            .map(CompletableFuture::join) // 각 비동기 작업의 결과를 기다림
+            .toList();
     }
 }

--- a/src/main/java/com/gamemoonchul/application/converter/PostConverter.java
+++ b/src/main/java/com/gamemoonchul/application/converter/PostConverter.java
@@ -28,13 +28,13 @@ public class PostConverter {
         return entity;
     }
 
-    public static RedisPostDetail toCache(Post post) {
+    public static RedisPostDetail toCache(Post post, Long commentCount) {
         return RedisPostDetail.builder()
             .id(post.getId())
             .author(MemberConverter.toResponseDto(post.getMember()))
             .videoUrl(post.getVideoUrl())
             .thumbnailUrl(post.getThumbnailUrl())
-            .commentCount(post.getCommentCount())
+            .commentCount(commentCount)
             .title(post.getTitle())
             .content(post.getContent())
             .timesAgo(StringUtils.getTimeAgo(post.getCreatedAt()))
@@ -96,7 +96,7 @@ public class PostConverter {
         return result;
     }
 
-    public static PostMainPageResponse entityToResponse(Post entity) {
+    public static PostMainPageResponse entityToResponse(Post entity, Integer commentCount) {
         List<Double> voteRatio = List.of(100 - entity.getVoteRatio(), entity.getVoteRatio());
         return PostMainPageResponse.builder()
             .id(entity.getId())
@@ -105,7 +105,7 @@ public class PostConverter {
             .thumbnailUrl(entity.getThumbnailUrl())
             .title(entity.getTitle())
             .content(entity.getContent())
-            .viewCount(entity.getViewCount())
+            .commentCount(commentCount)
             .timesAgo(StringUtils.getTimeAgo(entity.getCreatedAt()))
             .voteRatio(voteRatio)
             .build();

--- a/src/main/java/com/gamemoonchul/application/post/PostOpenApiService.java
+++ b/src/main/java/com/gamemoonchul/application/post/PostOpenApiService.java
@@ -1,14 +1,13 @@
 package com.gamemoonchul.application.post;
 
-import com.gamemoonchul.application.CommentService;
 import com.gamemoonchul.application.converter.CommentConverter;
 import com.gamemoonchul.application.converter.PostConverter;
 import com.gamemoonchul.common.exception.BadRequestException;
 import com.gamemoonchul.domain.entity.Post;
 import com.gamemoonchul.domain.entity.redis.RedisPostDetail;
 import com.gamemoonchul.domain.status.PostStatus;
+import com.gamemoonchul.infrastructure.repository.CommentRepository;
 import com.gamemoonchul.infrastructure.repository.PostRepository;
-import com.gamemoonchul.infrastructure.repository.redis.RedisPostDetailRepository;
 import com.gamemoonchul.infrastructure.web.common.Pagination;
 import com.gamemoonchul.infrastructure.web.dto.response.CommentResponse;
 import com.gamemoonchul.infrastructure.web.dto.response.PostMainPageResponse;
@@ -19,7 +18,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 
@@ -28,16 +29,18 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class PostOpenApiService {
     private final PostRepository postRepository;
-    private final CommentService commentService;
+    private final CommentRepository commentRepository;
+    private final ExecutorService executor = Executors.newFixedThreadPool(10);
 
     public RedisPostDetail getPostDetails(Long postId, Long requestMemberId) {
         Post post = postRepository.searchByPostId(postId).orElseThrow(() -> new BadRequestException(PostStatus.POST_NOT_FOUND));
         post.viewCountUp();
 
-        RedisPostDetail redisPostDetail = PostConverter.toCache(post);
-
-        List<CommentResponse> comments = commentService.searchByPostId(redisPostDetail.getId(), requestMemberId).stream()
+        List<CommentResponse> comments = commentRepository.searchByPostId(postId, requestMemberId).stream()
             .map(CommentConverter::toResponse).toList(); // 변경 자주 일어남, 캐싱 X
+
+        RedisPostDetail redisPostDetail = PostConverter.toCache(post, (long) comments.size());
+
         redisPostDetail.setComments(comments);
 
         return redisPostDetail;
@@ -45,30 +48,34 @@ public class PostOpenApiService {
 
     public Pagination<PostMainPageResponse> getLatestPosts(Long requestMemberId, int page, int size) {
         Page<Post> savedPage = postRepository.searchNewPostsWithoutBanPosts(requestMemberId, PageRequest.of(page, size));
-        List<PostMainPageResponse> responses = savedPage.getContent()
-            .stream()
-            .map(PostConverter::entityToResponse)
-            .collect(Collectors.toList());
-
+        List<PostMainPageResponse> responses = getPostMainPageResponses(savedPage);
         return new Pagination<>(savedPage, responses);
     }
 
     public Pagination<PostMainPageResponse> getGrillPosts(Long requestMemberId, int page, int size) {
         Page<Post> savedPage = postRepository.searchGrillPostsWithoutBanPosts(requestMemberId, PageRequest.of(page, size));
-        List<PostMainPageResponse> responses = savedPage.getContent()
-            .stream()
-            .map(PostConverter::entityToResponse)
-            .toList();
+        List<PostMainPageResponse> responses = getPostMainPageResponses(savedPage);
         return new Pagination<PostMainPageResponse>(savedPage, responses);
     }
 
     public Pagination<PostMainPageResponse> getHotPosts(int page, int size, Long requestMemberId) {
         Page<Post> savedPage = postRepository.searchHotPostWithoutBanPosts(requestMemberId, PageRequest.of(page, size));
-
-        List<PostMainPageResponse> responses = savedPage.getContent()
-            .stream()
-            .map(PostConverter::entityToResponse)
-            .toList();
+        List<PostMainPageResponse> responses = getPostMainPageResponses(savedPage);
         return new Pagination<>(savedPage, responses);
+    }
+
+    private List<PostMainPageResponse> getPostMainPageResponses(Page<Post> savedPage) {
+        List<CompletableFuture<PostMainPageResponse>> futures = savedPage.getContent()
+            .stream()
+            .map(post -> CompletableFuture.supplyAsync(() -> convertResponseDtoWithRepository(post), executor))
+            .toList();
+
+        List<PostMainPageResponse> responses = futures.stream().map(CompletableFuture::join).collect(Collectors.toList());
+        return responses;
+    }
+
+    private PostMainPageResponse convertResponseDtoWithRepository(Post post) {
+        Integer commentCount = commentRepository.countByPostId(post.getId());
+        return PostConverter.entityToResponse(post, commentCount);
     }
 }

--- a/src/main/java/com/gamemoonchul/common/ObjectMapperConfig.java
+++ b/src/main/java/com/gamemoonchul/common/ObjectMapperConfig.java
@@ -30,7 +30,7 @@ public class ObjectMapperConfig {
 //        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
         // 스네이크 케이스
-         objectMapper.setPropertyNamingStrategy(new PropertyNamingStrategies.SnakeCaseStrategy());
+//         objectMapper.setPropertyNamingStrategy(new PropertyNamingStrategies.SnakeCaseStrategy());
 
         return objectMapper;
     }

--- a/src/main/java/com/gamemoonchul/common/constants/RedisKeyConstant.java
+++ b/src/main/java/com/gamemoonchul/common/constants/RedisKeyConstant.java
@@ -1,7 +1,13 @@
 package com.gamemoonchul.common.constants;
 
 public class RedisKeyConstant {
+    /**
+     * Cacheable에서 사용하는 키
+     */
+    public static final String POST_COUNT_CACHEABLE = "post:count";
     public static String postCountKey(Long postId) {
-        return "post:count:" + postId;
+        // Cacheable에서 자동으로 뒤에 ::을 붙이기 때문에
+        // Sync를 맞출려면 붙여줘야 함
+        return POST_COUNT_CACHEABLE + "::" + postId;
     }
 }

--- a/src/main/java/com/gamemoonchul/config/RedisCacheManagerConfig.java
+++ b/src/main/java/com/gamemoonchul/config/RedisCacheManagerConfig.java
@@ -1,12 +1,15 @@
 package com.gamemoonchul.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gamemoonchul.common.constants.RedisKeyConstant;
 import com.gamemoonchul.domain.entity.Post;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -23,6 +26,7 @@ import java.time.Duration;
 public class RedisCacheManagerConfig {
     private final ObjectMapper objectMapper;
 
+    @Primary
     @Bean
     public CacheManager postCacheManager(RedisConnectionFactory cf) {
         RedisSerializer<Post> valueSerializer = new Jackson2JsonRedisSerializer<>(objectMapper.getTypeFactory().constructType(Post.class));
@@ -35,4 +39,14 @@ public class RedisCacheManagerConfig {
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf).cacheDefaults(redisCacheConfiguration).build();
     }
 
+    @Bean
+    public CacheManager commentCountCacheManager(RedisConnectionFactory cf) {
+        RedisSerializer<Integer> valueSerializer = new Jackson2JsonRedisSerializer<>(objectMapper.getTypeFactory().constructType(Integer.class));
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(valueSerializer)) // Value Serializer 변경
+            .entryTtl(Duration.ofMinutes(30L)); // 캐시 수명 30분
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf).cacheDefaults(redisCacheConfiguration).build();
+    }
 }

--- a/src/main/java/com/gamemoonchul/domain/entity/Post.java
+++ b/src/main/java/com/gamemoonchul/domain/entity/Post.java
@@ -74,14 +74,6 @@ public class Post extends BaseTimeEntity implements Serializable {
     @Version
     private Integer version;
 
-    public void commentCountDown() {
-        this.commentCount--;
-    }
-
-    public void commentCountUp() {
-        this.commentCount++;
-    }
-
     public void viewCountUp() {
         this.viewCount++;
     }

--- a/src/main/java/com/gamemoonchul/infrastructure/repository/CommentRepository.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/repository/CommentRepository.java
@@ -1,11 +1,13 @@
 package com.gamemoonchul.infrastructure.repository;
 
+import com.gamemoonchul.common.constants.RedisKeyConstant;
 import com.gamemoonchul.domain.entity.Comment;
 import com.gamemoonchul.domain.entity.Member;
 import com.gamemoonchul.domain.entity.Post;
 import com.gamemoonchul.infrastructure.repository.ifs.CommentRepositoryIfs;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.QueryHint;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -16,6 +18,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryIfs {
+    @Cacheable(value = RedisKeyConstant.POST_COUNT_CACHEABLE, key = "#postId", cacheManager = "commentCountCacheManager")
+    Integer countByPostId(Long postId);
+
     List<Comment> findByParentId(Long parentId);
 
     List<Comment> findAllByMember(Member member);

--- a/src/main/java/com/gamemoonchul/infrastructure/web/PostBanApiController.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/PostBanApiController.java
@@ -25,10 +25,7 @@ public class PostBanApiController {
     public List<PostMainPageResponse> getBannedPosts(
         @MemberSession Member member
     ) {
-        return postBanService.bannedPost(member.getId()).stream()
-            .map(PostBan::getBanPost)
-            .map(PostConverter::entityToResponse)
-            .toList();
+        return postBanService.bannedPostList(member.getId());
     }
 
     @PostMapping("/ban/{postId}")

--- a/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/PostMainPageResponse.java
+++ b/src/main/java/com/gamemoonchul/infrastructure/web/dto/response/PostMainPageResponse.java
@@ -13,7 +13,7 @@ public record PostMainPageResponse(
     String title,
     String content,
     String timesAgo,
-    Long viewCount,
+    Integer commentCount,
     List<Double> voteRatio
 ) {
 

--- a/src/test/java/com/gamemoonchul/application/PostBanServiceTest.java
+++ b/src/test/java/com/gamemoonchul/application/PostBanServiceTest.java
@@ -4,6 +4,7 @@ import com.gamemoonchul.TestDataBase;
 import com.gamemoonchul.domain.entity.*;
 import com.gamemoonchul.infrastructure.repository.MemberRepository;
 import com.gamemoonchul.infrastructure.repository.PostRepository;
+import com.gamemoonchul.infrastructure.web.dto.response.PostMainPageResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,8 +36,8 @@ class PostBanServiceTest extends TestDataBase {
         postBanService.ban(member2, post.getId());
 
         // then
-        List<PostBan> postBans = postBanService.bannedPost(member2.getId());
+        List<PostMainPageResponse> postBans = postBanService.bannedPostList(member2.getId());
         assertEquals(1, postBans.size());
-        assertThat(postBans.get(0).getBanPost().getTitle()).isEqualTo(post.getTitle());
+        assertThat(postBans.get(0).title()).isEqualTo(post.getTitle());
     }
 }


### PR DESCRIPTION
## Related Issue

Related to : #209 

## Overview

- 댓글 카운트를 가져올 때 Cache Aside Pattern으로 가져오도록 변경
- 댓글을 작성할 때 Cache에 댓글 카운트를 올리도록 변경

## Result

### 1000명의 유저가 동시에 댓글 입력한 결과 

- Redis 댓글 카운트

<img width="556" alt="image" src="https://github.com/user-attachments/assets/ee7bc235-9d21-4af2-99a4-dfbcc160d782">

- MySQL 쿼리 결과 댓글 카운트

<img width="511" alt="image" src="https://github.com/user-attachments/assets/1549aa10-0260-4b2e-8f9e-f49404d276dd">

- 실제 API 호출 결과

<img width="688" alt="image" src="https://github.com/user-attachments/assets/fdccf0e4-9f56-46e1-9962-0a0360653ac4">

### 성능테스트 

- 낙관락이 적용되있는 버전

TPS : 23343 / 600 = 39

![댓글작성테스트](https://github.com/user-attachments/assets/98cd3224-995e-49c4-8535-feaa4cabebaa)

- Redis에 캐싱을 하는 버전 

TPS : 75489 / 600 = 126

![댓글작성테스트2](https://github.com/user-attachments/assets/ea16d39f-dc6d-407d-b882-eb22064d766e)

## 결론 

TPS가 39에서 126으로 비약적으로 상승한 것을 알 수 있다.